### PR TITLE
fix: turbo helpers missing

### DIFF
--- a/lib/rails_error_dashboard.rb
+++ b/lib/rails_error_dashboard.rb
@@ -11,6 +11,8 @@ require "browser"
 require "groupdate"
 require "httparty"
 require "chartkick"
+require "turbo-rails"
+
 
 # Core library files
 require "rails_error_dashboard/value_objects/error_context"


### PR DESCRIPTION
Fixes #30 

Require 'turbo-rails' so that we can use the turbo helpers in views.

A thread regarding similar issue: https://github.com/hotwired/turbo-rails/issues/64