### PR TITLE
Mass assignment fix

### DIFF
--- a/app/controllers/rails_error_dashboard/errors_controller.rb
+++ b/app/controllers/rails_error_dashboard/errors_controller.rb
@@ -6,6 +6,23 @@ module RailsErrorDashboard
 
     before_action :authenticate_dashboard_user!
 
+    FILTERABLE_PARAMS = %i[
+      error_type
+      unresolved
+      platform
+      application_id
+      search
+      severity
+      timeframe
+      frequency
+      status
+      assigned_to
+      priority_level
+      hide_snoozed
+      sort_by
+      sort_direction
+    ].freeze
+
     def overview
       # Get dashboard stats using Query
       @stats = Queries::DashboardStats.call
@@ -266,24 +283,7 @@ module RailsErrorDashboard
     end
 
     def filter_params
-      {
-        error_type: params[:error_type],
-        unresolved: params[:unresolved],
-        platform: params[:platform],
-        application_id: params[:application_id],
-        search: params[:search],
-        severity: params[:severity],
-        timeframe: params[:timeframe],
-        frequency: params[:frequency],
-        # Phase 3: Workflow filter params
-        status: params[:status],
-        assigned_to: params[:assigned_to],
-        priority_level: params[:priority_level],
-        hide_snoozed: params[:hide_snoozed],
-        # Sorting params
-        sort_by: params[:sort_by],
-        sort_direction: params[:sort_direction]
-      }
+      params.permit(*FILTERABLE_PARAMS).to_h.symbolize_keys
     end
 
     def authenticate_dashboard_user!

--- a/app/views/layouts/rails_error_dashboard.html.erb
+++ b/app/views/layouts/rails_error_dashboard.html.erb
@@ -866,16 +866,20 @@
                 <% end %>
               </button>
               <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="appSwitcher">
+                <%
+                  base_route_params = request.path_parameters.slice(:controller, :action)
+                  current_filter_params = permitted_filter_params
+                %>
                 <li>
                   <%= link_to "All Applications",
-                      url_for(params.permit!.except(:controller, :action, :application_id)),
+                      url_for(base_route_params.merge(current_filter_params.except(:application_id))),
                       class: "dropdown-item #{'active' unless params[:application_id].present?}" %>
                 </li>
                 <li><hr class="dropdown-divider"></li>
                 <% @applications.each do |app_name, app_id| %>
                   <li>
                     <%= link_to app_name,
-                        url_for(params.permit!.except(:controller, :action).merge(application_id: app_id)),
+                        url_for(base_route_params.merge(current_filter_params.merge(application_id: app_id))),
                         class: "dropdown-item #{params[:application_id].to_s == app_id.to_s ? 'active' : ''}" %>
                   </li>
                 <% end %>

--- a/app/views/rails_error_dashboard/errors/index.html.erb
+++ b/app/views/rails_error_dashboard/errors/index.html.erb
@@ -158,7 +158,7 @@
         <% active_filters.each do |filter| %>
           <%
             # Build URL without this specific filter
-            filter_params = params.permit!.except(:controller, :action, filter[:param])
+            filter_params = permitted_filter_params.except(filter[:param])
           %>
           <%= link_to errors_path(filter_params), class: "badge bg-primary text-decoration-none filter-pill" do %>
             <%= filter[:label] %>


### PR DESCRIPTION
Created Filtable params to avoid this security problem

Brakeman info
Confidence: Medium
Category: Mass Assignment
Check: MassAssignment
Message: Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys Code: params.permit!
File: app/helpers/rails_error_dashboard/application_helper.rb Line: 107

Confidence: Medium
Category: Mass Assignment
Check: MassAssignment
Message: Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys
Code: params.permit!
File: app/views/layouts/rails_error_dashboard.html.erb
Line: 871

Confidence: Medium
Category: Mass Assignment
Check: MassAssignment
Message: Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys
Code: params.permit!
File: app/views/layouts/rails_error_dashboard.html.erb
Line: 878

Confidence: Medium
Category: Mass Assignment
Check: MassAssignment
Message: Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys
Code: params.permit!
File: app/views/rails_error_dashboard/errors/index.html.erb
Line: 161