### PR TITLE
feat: add line numbers to stack trace frames

### DIFF
--- a/app/views/layouts/rails_error_dashboard.html.erb
+++ b/app/views/layouts/rails_error_dashboard.html.erb
@@ -1148,6 +1148,22 @@ body.dark-mode .source-file-path {
   color: var(--ctp-text) !important; /* Bright text for dark mode */
 }
 
+/* Backtrace frame number styling */
+.backtrace-frame-number {
+  display: inline-block;
+  min-width: 2em;
+  text-align: right;
+  margin-right: 0.5em;
+  color: #9ca3af;
+  font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Fira Code', monospace;
+  font-size: 0.85em;
+  user-select: none;
+}
+
+body.dark-mode .backtrace-frame-number {
+  color: var(--ctp-overlay1);
+}
+
 /* Backtrace method name styling - override Bootstrap text-info */
 span.backtrace-method-name {
   color: #0066cc !important; /* Darker blue for better readability in light mode */

--- a/app/views/rails_error_dashboard/errors/show.html.erb
+++ b/app/views/rails_error_dashboard/errors/show.html.erb
@@ -166,6 +166,7 @@
                         <!-- Frame header (always visible) -->
                         <div class="<%= frame_bg_class(frame[:category]) %> d-flex justify-content-between align-items-center px-2 py-1">
                           <div>
+                            <span class="backtrace-frame-number"><%= index + 1 %></span>
                             <span class="<%= frame_color_class(frame[:category]) %>">
                               <%= frame_icon(frame[:category]) %> <%= frame[:short_path] %>:<%= frame[:line_number] %>
                             </span> in <span class="backtrace-method-name">`<%= frame[:method_name] %>'</span>
@@ -209,7 +210,7 @@
                   <div id="frameworkBacktrace" class="accordion-collapse collapse" data-bs-parent="#frameworkBacktraceAccordion">
                     <div class="accordion-body p-0">
                       <div class="code-block p-3" style="max-height: 400px; overflow-y: auto; overflow-x: auto;">
-                        <pre class="mb-0"><code><% framework_frames.each do |frame| %><span class="<%= frame_bg_class(frame[:category]) %> d-block px-2 py-1"><span class="<%= frame_color_class(frame[:category]) %>"><%= frame_icon(frame[:category]) %> <%= frame[:short_path] %>:<%= frame[:line_number] %></span> in <span class="backtrace-method-name">`<%= frame[:method_name] %>'</span></span>
+                        <pre class="mb-0"><code><% framework_frames.each_with_index do |frame, index| %><span class="<%= frame_bg_class(frame[:category]) %> d-block px-2 py-1"><span class="backtrace-frame-number"><%= index + 1 %></span><span class="<%= frame_color_class(frame[:category]) %>"><%= frame_icon(frame[:category]) %> <%= frame[:short_path] %>:<%= frame[:line_number] %></span> in <span class="backtrace-method-name">`<%= frame[:method_name] %>'</span></span>
 <% end %></code></pre>
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- Adds numbered frame indicators (1, 2, 3...) to each backtrace entry in the error detail view
- Covers both the application frames (accordion) and framework frames sections
- Styled with monospace font, muted color, and non-selectable text for clean copy/paste
- Includes dark mode support

Closes #65

## Test plan
- [ ] Visit an error detail page with a multi-frame backtrace
- [ ] Verify frame numbers appear in both application and framework backtrace sections
- [ ] Verify numbers are right-aligned and visually distinct from the frame content
- [ ] Check appearance in both light and dark mode
- [ ] Confirm frame numbers are not included when selecting/copying backtrace text

## Screenshot

<img width="831" height="606" alt="image" src="https://github.com/user-attachments/assets/238ca660-609d-450e-8ce0-33c95b1dd575" />
