### PR TITLE
Feat/43 loading states skeleton screens

### DIFF
--- a/app/views/layouts/rails_error_dashboard.html.erb
+++ b/app/views/layouts/rails_error_dashboard.html.erb
@@ -1320,6 +1320,65 @@ body.dark-mode .timeline-item:hover .timeline-content {
 #sidebarToggle:hover i {
   transform: scale(1.1);
 }
+
+/* Skeleton Loading Animations */
+@keyframes shimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+
+.skeleton {
+  background: linear-gradient(90deg, #e5e7eb 25%, #f3f4f6 50%, #e5e7eb 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s ease-in-out infinite;
+  border-radius: 4px;
+}
+
+body.dark-mode .skeleton {
+  background: linear-gradient(90deg, #313244 25%, #45475a 50%, #313244 75%);
+  background-size: 200% 100%;
+}
+
+.skeleton-text {
+  height: 1em;
+  width: 60%;
+  margin-bottom: 0.5em;
+}
+
+.skeleton-text-short {
+  width: 40%;
+}
+
+.skeleton-card {
+  height: 80px;
+}
+
+.skeleton-row {
+  height: 48px;
+  margin-bottom: 2px;
+}
+
+.skeleton-chart {
+  height: 250px;
+}
+
+/* Hide skeleton containers by default */
+.loading-skeleton {
+  display: none;
+}
+
+/* Loading spinner for buttons */
+.btn .loading-spinner {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: spinner-border 0.75s linear infinite;
+  vertical-align: middle;
+  margin-right: 0.25em;
+}
     </style>
   </head>
 
@@ -1566,6 +1625,98 @@ body.dark-mode .timeline-item:hover .timeline-content {
     <!-- Bootstrap JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 
+    <!-- Stimulus (for loading state management) -->
+    <script src="https://cdn.jsdelivr.net/npm/@hotwired/stimulus@3.2.2/dist/stimulus.min.js"></script>
+
+    <!-- Loading State Controller -->
+    <script>
+(function() {
+  'use strict';
+  if (typeof Stimulus === 'undefined') return;
+
+  var application = Stimulus.Application.start();
+
+  application.register('loading', class extends Stimulus.Controller {
+    static get targets() {
+      return ['skeleton', 'content', 'submitButton'];
+    }
+
+    connect() {
+      this._boundHideSkeletons = this.hideSkeletons.bind(this);
+      document.addEventListener('turbo:before-stream-render', this._boundHideSkeletons);
+      document.addEventListener('turbo:load', this._boundHideSkeletons);
+    }
+
+    disconnect() {
+      document.removeEventListener('turbo:before-stream-render', this._boundHideSkeletons);
+      document.removeEventListener('turbo:load', this._boundHideSkeletons);
+      if (this._safetyTimeout) clearTimeout(this._safetyTimeout);
+    }
+
+    // Called on filter form submit
+    submit() {
+      this.showSkeletons();
+      this.disableSubmitButtons();
+      this.startSafetyTimeout();
+    }
+
+    // Called on async action button click
+    click(event) {
+      var button = event.currentTarget;
+      if (button.disabled) return;
+
+      button.disabled = true;
+      var originalHTML = button.dataset.loadingOriginalHtml;
+      if (!originalHTML) {
+        button.dataset.loadingOriginalHtml = button.innerHTML;
+      }
+      var spinnerHTML = '<span class="loading-spinner"></span>';
+      var buttonText = button.textContent.trim();
+      button.innerHTML = spinnerHTML + ' ' + buttonText;
+    }
+
+    showSkeletons() {
+      this.skeletonTargets.forEach(function(el) { el.style.display = ''; });
+      this.contentTargets.forEach(function(el) { el.style.display = 'none'; });
+    }
+
+    hideSkeletons() {
+      this.skeletonTargets.forEach(function(el) { el.style.display = 'none'; });
+      this.contentTargets.forEach(function(el) { el.style.display = ''; });
+      this.enableSubmitButtons();
+      if (this._safetyTimeout) clearTimeout(this._safetyTimeout);
+    }
+
+    disableSubmitButtons() {
+      this.submitButtonTargets.forEach(function(btn) {
+        btn.disabled = true;
+        if (!btn.dataset.loadingOriginalHtml) {
+          btn.dataset.loadingOriginalHtml = btn.innerHTML;
+        }
+        var spinnerHTML = '<span class="loading-spinner"></span>';
+        btn.innerHTML = spinnerHTML + ' Loading...';
+      });
+    }
+
+    enableSubmitButtons() {
+      this.submitButtonTargets.forEach(function(btn) {
+        btn.disabled = false;
+        if (btn.dataset.loadingOriginalHtml) {
+          btn.innerHTML = btn.dataset.loadingOriginalHtml;
+          delete btn.dataset.loadingOriginalHtml;
+        }
+      });
+    }
+
+    startSafetyTimeout() {
+      var self = this;
+      this._safetyTimeout = setTimeout(function() {
+        self.hideSkeletons();
+      }, 10000);
+    }
+  });
+})();
+    </script>
 
     <!-- Dashboard JavaScript (inline for production compatibility) -->
 

--- a/app/views/rails_error_dashboard/errors/index.html.erb
+++ b/app/views/rails_error_dashboard/errors/index.html.erb
@@ -5,7 +5,7 @@
   <%= turbo_stream_from "error_list" %>
 <% end %>
 
-<div class="py-4">
+<div class="py-4" data-controller="loading">
   <div class="d-flex justify-content-between align-items-center mb-4">
     <h2 class="mb-0"><i class="bi bi-bug-fill text-primary"></i> Error Overview</h2>
     <div class="text-muted">
@@ -20,7 +20,23 @@
 
   <!-- Stats Cards -->
   <div id="dashboard_stats" class="mb-4">
-    <%= render "stats", stats: @stats %>
+    <div data-loading-target="content">
+      <%= render "stats", stats: @stats %>
+    </div>
+    <div class="loading-skeleton" data-loading-target="skeleton">
+      <div class="row g-4">
+        <% 4.times do %>
+          <div class="col-md-3">
+            <div class="card stat-card">
+              <div class="card-body">
+                <div class="skeleton skeleton-text skeleton-text-short mb-2"></div>
+                <div class="skeleton skeleton-card"></div>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
   </div>
 
   <!-- Top Error Types (Only show if there are errors) -->
@@ -77,7 +93,7 @@
   <!-- 7-Day Error Trend (requires chartkick gem) -->
   <% if @stats[:errors_trend_7d]&.any? && respond_to?(:line_chart) %>
     <div class="row g-4 mb-4">
-      <div class="col-md-8">
+      <div class="col-md-8" data-loading-target="content">
         <div class="card">
           <div class="card-header bg-white d-flex justify-content-between align-items-center">
             <h5 class="mb-0"><i class="bi bi-graph-up"></i> 7-Day Error Trend</h5>
@@ -105,7 +121,7 @@
           </div>
         </div>
       </div>
-      <div class="col-md-4">
+      <div class="col-md-4" data-loading-target="content">
         <div class="card">
           <div class="card-header bg-white">
             <h5 class="mb-0"><i class="bi bi-pie-chart"></i> By Severity (7d)</h5>
@@ -116,6 +132,31 @@
                 height: "250px",
                 legend: "bottom",
                 donut: true %>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="loading-skeleton" data-loading-target="skeleton">
+      <div class="row g-4 mb-4">
+        <div class="col-md-8">
+          <div class="card">
+            <div class="card-header bg-white">
+              <div class="skeleton skeleton-text" style="width: 200px;"></div>
+            </div>
+            <div class="card-body">
+              <div class="skeleton skeleton-chart"></div>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-4">
+          <div class="card">
+            <div class="card-header bg-white">
+              <div class="skeleton skeleton-text" style="width: 150px;"></div>
+            </div>
+            <div class="card-body">
+              <div class="skeleton skeleton-chart"></div>
+            </div>
           </div>
         </div>
       </div>
@@ -193,7 +234,7 @@
             class: "btn btn-sm #{params[:reopened] == 'true' ? 'btn-primary' : 'btn-outline-primary'}" %>
       </div>
 
-      <%= form_with url: errors_path, method: :get, class: "row g-3", data: { turbo: false } do %>
+      <%= form_with url: errors_path, method: :get, class: "row g-3", data: { turbo: false, action: "submit->loading#submit" } do %>
         <% if params[:reopened].present? %>
           <%= hidden_field_tag :reopened, params[:reopened] %>
         <% end %>
@@ -323,7 +364,7 @@
         </div>
 
         <div class="col-12 mt-3">
-          <%= submit_tag "Apply Filters", class: "btn btn-primary" %>
+          <%= submit_tag "Apply Filters", class: "btn btn-primary", data: { loading_target: "submitButton" } %>
           <%= link_to "Clear", errors_path, class: "btn btn-outline-secondary" %>
         </div>
       <% end %>
@@ -365,42 +406,52 @@
 
     <div class="card-body p-0">
       <% if @errors.any? %>
-        <div class="table-responsive">
-          <table class="table table-hover mb-0">
-            <thead class="table-light">
-              <tr>
-                <th style="width: 40px;">
-                  <input type="checkbox" id="select-all" class="form-check-input">
-                </th>
-                <th><%= sortable_header("Severity", "severity") %></th>
-                <th><%= sortable_header("Error Type", "error_type") %></th>
-                <th>Message</th>
-                <th><%= sortable_header("Occurrences", "occurrence_count") %></th>
-                <th><%= sortable_header("First / Last Seen", "last_seen_at") %></th>
+        <div data-loading-target="content">
+          <div class="table-responsive">
+            <table class="table table-hover mb-0">
+              <thead class="table-light">
+                <tr>
+                  <th style="width: 40px;">
+                    <input type="checkbox" id="select-all" class="form-check-input">
+                  </th>
+                  <th><%= sortable_header("Severity", "severity") %></th>
+                  <th><%= sortable_header("Error Type", "error_type") %></th>
+                  <th>Message</th>
+                  <th><%= sortable_header("Occurrences", "occurrence_count") %></th>
+                  <th><%= sortable_header("First / Last Seen", "last_seen_at") %></th>
 
-                <!-- Show App column only when viewing all apps -->
-                <% if @applications.size > 1 && params[:application_id].blank? %>
-                  <th><%= sortable_header("Application", "application_id") %></th>
-                <% end %>
+                  <!-- Show App column only when viewing all apps -->
+                  <% if @applications.size > 1 && params[:application_id].blank? %>
+                    <th><%= sortable_header("Application", "application_id") %></th>
+                  <% end %>
 
-                <% if @platforms.size > 1 %>
-                  <th><%= sortable_header("Platform", "platform") %></th>
+                  <% if @platforms.size > 1 %>
+                    <th><%= sortable_header("Platform", "platform") %></th>
+                  <% end %>
+                  <th>Status</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody id="error_list">
+                <% @errors.each do |error| %>
+                  <%= render "error_row", error: error, show_platform: @platforms.size > 1, show_application: (@applications.size > 1 && params[:application_id].blank?) %>
                 <% end %>
-                <th>Status</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody id="error_list">
-              <% @errors.each do |error| %>
-                <%= render "error_row", error: error, show_platform: @platforms.size > 1, show_application: (@applications.size > 1 && params[:application_id].blank?) %>
-              <% end %>
-            </tbody>
-          </table>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- Pagination -->
+          <div class="p-3">
+            <%== @pagy.series_nav(:bootstrap) if @pagy.pages > 1 %>
+          </div>
         </div>
 
-        <!-- Pagination -->
-        <div class="p-3">
-          <%== @pagy.series_nav(:bootstrap) if @pagy.pages > 1 %>
+        <div class="loading-skeleton" data-loading-target="skeleton">
+          <div class="p-3">
+            <% 5.times do %>
+              <div class="skeleton skeleton-row mb-2"></div>
+            <% end %>
+          </div>
         </div>
       <% else %>
         <div class="text-center py-5">

--- a/app/views/rails_error_dashboard/errors/show.html.erb
+++ b/app/views/rails_error_dashboard/errors/show.html.erb
@@ -57,7 +57,7 @@
   }
 </script>
 
-<div class="py-4">
+<div class="py-4" data-controller="loading">
   <!-- Breadcrumbs -->
   <nav aria-label="breadcrumb" class="mb-3">
     <ol class="breadcrumb">
@@ -1214,7 +1214,7 @@
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-          <%= submit_tag "Mark as Resolved", class: "btn btn-success" %>
+          <%= submit_tag "Mark as Resolved", class: "btn btn-success", data: { action: "click->loading#click" } %>
         </div>
       <% end %>
     </div>
@@ -1241,7 +1241,7 @@
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-          <%= submit_tag "Assign", class: "btn btn-primary" %>
+          <%= submit_tag "Assign", class: "btn btn-primary", data: { action: "click->loading#click" } %>
         </div>
       <% end %>
     </div>
@@ -1273,7 +1273,7 @@
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-          <%= submit_tag "Update Priority", class: "btn btn-warning" %>
+          <%= submit_tag "Update Priority", class: "btn btn-warning", data: { action: "click->loading#click" } %>
         </div>
       <% end %>
     </div>
@@ -1315,7 +1315,7 @@
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-          <%= submit_tag "Snooze", class: "btn btn-warning" %>
+          <%= submit_tag "Snooze", class: "btn btn-warning", data: { action: "click->loading#click" } %>
         </div>
       <% end %>
     </div>

--- a/spec/system/loading_states_spec.rb
+++ b/spec/system/loading_states_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Loading States", type: :system do
+  let!(:application) { create(:application) }
+  let!(:error_log) { create(:error_log, application: application) }
+
+  describe "skeleton screens" do
+    it "has skeleton placeholders for dashboard stats" do
+      visit_dashboard("/errors")
+      wait_for_page_load
+
+      # Skeleton containers exist but are hidden
+      expect(page).to have_css(".loading-skeleton", visible: :hidden)
+      expect(page).to have_css(".skeleton.skeleton-card", visible: :hidden)
+    end
+
+    it "has skeleton placeholders for error list" do
+      visit_dashboard("/errors")
+      wait_for_page_load
+
+      expect(page).to have_css(".skeleton.skeleton-row", visible: :hidden)
+    end
+
+    it "has a loading controller on the page" do
+      visit_dashboard("/errors")
+      wait_for_page_load
+
+      expect(page).to have_css("[data-controller='loading']")
+    end
+  end
+
+  describe "button loading states" do
+    it "has loading action on filter submit button" do
+      visit_dashboard("/errors")
+      wait_for_page_load
+
+      expect(page).to have_css("[data-loading-target='submitButton']")
+    end
+  end
+
+  describe "async action button loading states" do
+    let!(:unresolved_error) do
+      create(:error_log,
+        application: application,
+        resolved: false,
+        status: "new",
+        priority_level: 0)
+    end
+
+    it "has loading action on modal submit buttons" do
+      visit_error(unresolved_error)
+      wait_for_page_load
+
+      # The resolve button opens a modal
+      expect(page).to have_css("[data-bs-target='#resolveModal']")
+
+      # Modal submit buttons should have loading actions
+      expect(page).to have_css("input[data-action='click->loading#click']", visible: :hidden)
+    end
+  end
+end


### PR DESCRIPTION
## Description

##Summary
- Add Stimulus via CDN with an inline LoadingController for managing loading states
- Add CSS skeleton screen animations (shimmer gradient) for dashboard stats, error list, and charts
- Add loading spinner + disabled state on filter form submit and async action buttons (Resolve, Assign, Priority, Snooze)
- 10-second safety timeout auto-restores UI if response never arrives

Closes #43

## Test plan
- [ ] System tests verify skeleton elements exist in DOM with correct CSS classes
- [ ] System tests verify loading controller and button targets are present
- [ ] Full suite passes (1661 examples, 0 failures)
- [ ] Manual: `HEADLESS=false bundle exec rspec spec/system/loading_states_spec.rb` to visually verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [x] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [ ] ♻️ Code refactoring
- [ ] 🔧 Configuration change
- [ ] 🧪 Test improvement
- [ ] 🔒 Security fix

## Related Issues

Closes #43

