### PR TITLE
fix(llm-observability): filter overreach + word-break (v0.7.0 follow-ups)

### DIFF
--- a/app/views/rails_error_dashboard/errors/_llm_summary.html.erb
+++ b/app/views/rails_error_dashboard/errors/_llm_summary.html.erb
@@ -66,14 +66,14 @@
           <hr class="my-2">
           <small class="text-muted d-block mb-2">By model</small>
           <% llm_summary[:by_model].each do |row| %>
-            <div class="d-flex justify-content-between align-items-center mb-1">
-              <small style="word-break: break-all;">
+            <div class="d-flex justify-content-between align-items-center mb-1" style="gap: 0.5rem;">
+              <small style="min-width: 0; overflow-wrap: anywhere;" title="<%= [ row[:provider], row[:model].presence || "unknown" ].compact.join(" · ") %>">
                 <% if row[:provider].present? %>
                   <span class="text-muted"><%= row[:provider] %>·</span>
                 <% end %>
                 <strong><%= row[:model].presence || "unknown" %></strong>
               </small>
-              <small class="text-muted">
+              <small class="text-muted text-nowrap">
                 <%= row[:calls] %> · <%= number_with_delimiter(row[:tokens]) %>tok
                 <% if row[:cost_usd] > 0 %>
                   · $<%= "%.4f" % row[:cost_usd] %>

--- a/lib/rails_error_dashboard/services/breadcrumb_collector.rb
+++ b/lib/rails_error_dashboard/services/breadcrumb_collector.rb
@@ -18,6 +18,23 @@ module RailsErrorDashboard
       MAX_METADATA_VALUE_LENGTH = 200
       MAX_METADATA_KEYS = 10
 
+      # Categories whose metadata is emitted by LlmCallEvent#to_breadcrumb_metadata.
+      LLM_CATEGORIES = %w[llm llm_tool].freeze
+
+      # Keys on llm / llm_tool crumbs whose values are structured (numeric counts,
+      # identifiers, durations, costs) and must not be redacted by the
+      # ActiveSupport::ParameterFilter substring matcher. Without this whitelist,
+      # the default `:token` pattern matches `input_tokens` / `output_tokens` and
+      # corrupts the LlmSummary rollup, sidebar card, and markdown export tokens
+      # column. Sensitive-looking fields like tool_arguments / tool_result /
+      # error_message are intentionally NOT in this list — they go through the
+      # filter as usual because they can carry user-provided content.
+      LLM_STRUCTURED_METADATA_KEYS = %w[
+        provider model status
+        input_tokens output_tokens duration_ms
+        tool_name error_class cost_usd
+      ].freeze
+
       # Fixed-size ring buffer — O(1) append, wraps around when full
       class RingBuffer
         def initialize(max_size)
@@ -156,7 +173,7 @@ module RailsErrorDashboard
 
           # Filter metadata values
           if filtered[:meta].is_a?(Hash)
-            filtered[:meta] = filter.filter(filtered[:meta])
+            filtered[:meta] = filter_metadata_for_crumb(filter, filtered[:c], filtered[:meta])
           end
 
           filtered
@@ -165,6 +182,22 @@ module RailsErrorDashboard
         RailsErrorDashboard::Logger.debug("[RailsErrorDashboard] BreadcrumbCollector.filter_sensitive failed: #{e.message}")
         breadcrumbs.is_a?(Array) ? breadcrumbs : []
       end
+
+      # Apply the sensitive-data filter to a single breadcrumb's metadata hash,
+      # with a narrow whitelist for llm/llm_tool crumbs. The default
+      # ActiveSupport::ParameterFilter does substring matching (e.g. the `:token`
+      # default redacts every key containing "token"), which corrupts the
+      # structured numeric metadata emitted by LlmCallEvent. For llm/llm_tool
+      # crumbs we filter only the non-whitelisted keys, then merge the
+      # untouched structured keys back in.
+      def self.filter_metadata_for_crumb(filter, category, metadata)
+        return filter.filter(metadata) unless LLM_CATEGORIES.include?(category.to_s)
+
+        structured, rest = metadata.partition { |k, _| LLM_STRUCTURED_METADATA_KEYS.include?(k.to_s) }
+        filtered_rest = filter.filter(rest.to_h)
+        structured.to_h.merge(filtered_rest)
+      end
+      private_class_method :filter_metadata_for_crumb
 
       # Truncate message to MAX_MESSAGE_LENGTH
       def self.truncate_message(message)

--- a/spec/services/breadcrumb_collector_spec.rb
+++ b/spec/services/breadcrumb_collector_spec.rb
@@ -351,5 +351,64 @@ RSpec.describe RailsErrorDashboard::Services::BreadcrumbCollector do
       expect { described_class.filter_sensitive(nil) }.not_to raise_error
       expect { described_class.filter_sensitive("bad") }.not_to raise_error
     end
+
+    context "LLM crumb numeric metadata" do
+      # Regression for v0.7.0 zerocourse integration test: the default
+      # ParameterFilter pattern `:token` does substring matching, so it
+      # was redacting `input_tokens` / `output_tokens` (and any other
+      # `*_token*` key) on LLM breadcrumbs. That broke the LlmSummary
+      # rollup (showed 0 tokens), the sidebar card, and the markdown
+      # export tokens column.
+      it "preserves input_tokens and output_tokens on llm crumbs" do
+        breadcrumbs = [
+          { c: "llm", m: "gemini · gemini-2.5-flash · in:13/out:197", t: 1000,
+            meta: { "input_tokens" => 13, "output_tokens" => 197, "model" => "gemini-2.5-flash", "cost_usd" => 0.00006 } }
+        ]
+
+        result = described_class.filter_sensitive(breadcrumbs)
+        expect(result.first[:meta]["input_tokens"]).to eq(13)
+        expect(result.first[:meta]["output_tokens"]).to eq(197)
+        expect(result.first[:meta]["model"]).to eq("gemini-2.5-flash")
+        expect(result.first[:meta]["cost_usd"]).to eq(0.00006)
+      end
+
+      it "preserves the same numeric metadata on llm_tool crumbs" do
+        breadcrumbs = [
+          { c: "llm_tool", m: "tool: read_file", t: 1000,
+            meta: { "input_tokens" => 12, "output_tokens" => 8, "tool_name" => "read_file", "duration_ms" => 42 } }
+        ]
+
+        result = described_class.filter_sensitive(breadcrumbs)
+        expect(result.first[:meta]["input_tokens"]).to eq(12)
+        expect(result.first[:meta]["output_tokens"]).to eq(8)
+        expect(result.first[:meta]["tool_name"]).to eq("read_file")
+      end
+
+      it "still filters genuinely sensitive keys on llm crumbs" do
+        breadcrumbs = [
+          { c: "llm", m: "tool: send_email", t: 1000,
+            meta: { "input_tokens" => 10, "tool_arguments" => "api_key=sk-real-secret", "password" => "hunter2" } }
+        ]
+
+        result = described_class.filter_sensitive(breadcrumbs)
+        # Numeric metadata preserved
+        expect(result.first[:meta]["input_tokens"]).to eq(10)
+        # Actually-sensitive keys still redacted
+        expect(result.first[:meta]["password"]).to eq("[FILTERED]")
+      end
+
+      it "leaves non-llm crumb metadata behavior unchanged" do
+        # A `custom` crumb with the same `input_tokens` key should still
+        # be redacted — the fix is scoped to llm/llm_tool categories only.
+        breadcrumbs = [
+          { c: "custom", m: "weird app metric", t: 1000,
+            meta: { "input_tokens" => 42, "password" => "secret" } }
+        ]
+
+        result = described_class.filter_sensitive(breadcrumbs)
+        expect(result.first[:meta]["input_tokens"]).to eq("[FILTERED]")
+        expect(result.first[:meta]["password"]).to eq("[FILTERED]")
+      end
+    end
   end
 end

--- a/spec/services/llm_summary_spec.rb
+++ b/spec/services/llm_summary_spec.rb
@@ -178,5 +178,44 @@ RSpec.describe RailsErrorDashboard::Services::LlmSummary do
         expect(described_class.call([ weird ])).to be_nil
       end
     end
+
+    context "post-filter integration with BreadcrumbCollector" do
+      # Regression for v0.7.0 Bug 2 (sidebar Tokens rollup shows 0): the rollup
+      # was reading "[FILTERED]" out of the filtered metadata and calling .to_i
+      # on it, getting 0. The fix is in BreadcrumbCollector.filter_sensitive
+      # (whitelisting structured LLM metadata keys); this spec proves the full
+      # pipeline now produces a correct rollup.
+      before do
+        RailsErrorDashboard.configuration.filter_sensitive_data = true
+        RailsErrorDashboard::Services::SensitiveDataFilter.reset!
+        allow(Rails.application.config).to receive(:filter_parameters).and_return([])
+      end
+
+      after { RailsErrorDashboard::Services::SensitiveDataFilter.reset! }
+
+      it "rolls up real token counts after running through filter_sensitive" do
+        # Crumbs as BreadcrumbCollector produces them (string values per
+        # truncate_metadata's stringification step).
+        raw = [
+          { c: "llm", m: "gemini · gemini-2.5-flash", t: 1, d: 1771.7,
+            meta: { "provider" => "gemini", "model" => "gemini-2.5-flash",
+                    "status" => "success",
+                    "input_tokens" => "13", "output_tokens" => "197",
+                    "cost_usd" => "0.00006" } }
+        ]
+
+        filtered = RailsErrorDashboard::Services::BreadcrumbCollector.filter_sensitive(raw)
+        # LlmSummary expects string keys (HashWithIndifferentAccess from JSON.parse
+        # in views). Convert symbol keys for parity with the production path.
+        stringified = filtered.map { |c| c.transform_keys(&:to_s) }
+        result = described_class.call(stringified)
+
+        expect(result[:total_input_tokens]).to eq(13)
+        expect(result[:total_output_tokens]).to eq(197)
+        expect(result[:total_tokens]).to eq(210)
+        expect(result[:total_cost_usd]).to be_within(0.000001).of(0.00006)
+        expect(result[:by_model].first[:tokens]).to eq(210)
+      end
+    end
   end
 end

--- a/spec/views/rails_error_dashboard/errors/_llm_summary.html.erb_spec.rb
+++ b/spec/views/rails_error_dashboard/errors/_llm_summary.html.erb_spec.rb
@@ -96,6 +96,21 @@ RSpec.describe "rails_error_dashboard/errors/_llm_summary.html.erb", type: :view
       expect(rendered).to include("openai")
     end
 
+    it "does not use word-break: break-all on the model name (Bug 3 regression)" do
+      # v0.7.0 used `word-break: break-all` which split "gemini-2.5-flash"
+      # mid-word as "gemini-2.5-fla" + "sh". Fix uses overflow-wrap: anywhere,
+      # which respects natural break points (hyphens) and only breaks mid-word
+      # as a last resort.
+      render_partial(error)
+      expect(rendered).not_to include("word-break: break-all")
+      expect(rendered).to include("overflow-wrap: anywhere")
+    end
+
+    it "adds a title tooltip showing the full provider · model string" do
+      render_partial(error)
+      expect(rendered).to include('title="openai · gpt-4o-mini"')
+    end
+
     it "does not render an error alert when all calls succeed" do
       render_partial(error)
       expect(rendered).not_to include("failed call")


### PR DESCRIPTION
## Summary

Two small fixes for issues discovered during the v0.7.0 integration test on zerocourse (see `tasks/v0.7.0-zerocourse-test-findings.md`).

### Bug 1 + 2: `filter_sensitive_data` was redacting LLM token counts

The default `ActiveSupport::ParameterFilter` pattern `:token` does **substring matching**, so it redacted `input_tokens` and `output_tokens` on every `llm` / `llm_tool` breadcrumb. The fallout cascaded:

- Sidebar "LLM Calls" card showed **0 Tokens / 0 Input / 0 Output**
- "By model" row showed **0tok**
- Markdown export Tokens column showed `[FILTERED]/[FILTERED]`
- `LlmSummary` called `.to_i` on `"[FILTERED]"` → got `0` → silently corrupted every downstream rollup

**Fix** (`lib/rails_error_dashboard/services/breadcrumb_collector.rb`): `filter_sensitive` now uses a narrow whitelist (`LLM_STRUCTURED_METADATA_KEYS`) when the crumb category is `llm` or `llm_tool`. Whitelisted keys are structured non-content fields: `provider`, `model`, `status`, `input_tokens`, `output_tokens`, `duration_ms`, `tool_name`, `error_class`, `cost_usd`. Other keys — notably `tool_arguments`, `tool_result`, and `error_message` which can carry user-provided content — still go through the filter.

Behavior on non-LLM crumbs is intentionally unchanged: a `custom` crumb with an `input_tokens` key still gets redacted. The fix is scoped to `llm`/`llm_tool` because that's the only category where the metadata is emitted by `LlmCallEvent#to_breadcrumb_metadata` with a known structured shape.

### Bug 3: `word-break: break-all` split model names mid-character

The sidebar "By model" row rendered `gemini-2.5-flash` as `gemini-2.5-fla` / `sh` because `word-break: break-all` ignores natural word boundaries.

**Fix** (`app/views/rails_error_dashboard/errors/_llm_summary.html.erb`): switch to `overflow-wrap: anywhere` + `min-width: 0`, which respects hyphens / separators and only breaks mid-word as a last resort. Also added a `title` tooltip for the full `provider · model` string and `text-nowrap` on the metrics row.

## Test plan

- [x] **RSpec full suite**: 3314 examples, 0 failures, 1 pending (was 3307 — +7 new specs)
- [x] **RuboCop**: 493 files, 0 offenses
- [x] **Lefthook chaos tests**: passed on commit (`pre-release-test all`, 72s)
- [x] **End-to-end on zerocourse with local-path gem**: real Gemini call (13 input + 235 output tokens) shows correct numbers in sidebar, breadcrumb trail, and markdown export. Model name wraps at hyphen boundary, not mid-character.
- [ ] CI green on this PR

## Specs added

- `spec/services/breadcrumb_collector_spec.rb` — 4 new specs:
  - preserves `input_tokens`/`output_tokens` on `llm` crumbs
  - preserves same fields on `llm_tool` crumbs
  - still filters genuinely sensitive keys (`password`, etc.) on LLM crumbs
  - leaves non-LLM crumb metadata behavior unchanged (`custom` crumb with `input_tokens` still gets redacted)
- `spec/services/llm_summary_spec.rb` — 1 integration spec proving the full `BreadcrumbCollector → LlmSummary` pipeline now rolls up tokens correctly after filtering
- `spec/views/rails_error_dashboard/errors/_llm_summary.html.erb_spec.rb` — 2 new specs:
  - asserts `word-break: break-all` is gone and `overflow-wrap: anywhere` is present
  - asserts the `title` tooltip renders with the full `provider · model` string

## Files

- `lib/rails_error_dashboard/services/breadcrumb_collector.rb` (+35 lines, -1)
- `app/views/rails_error_dashboard/errors/_llm_summary.html.erb` (+3 lines, -2)
- 3 spec files (+150 lines total)

## Release impact

This is a `fix:` commit pair on the v0.7.0 line. Release-please should auto-open a v0.7.1 release PR after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)