### PR TITLE
docs(seo): surface all major capabilities in gemspec + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 gem 'rails_error_dashboard'
 ```
 
-**5-minute setup** · **Works out-of-the-box** · **Postgres, MySQL/Trilogy, SQLite** · **No vendor lock-in**
+**5-minute setup** · **Works out-of-the-box** · **PostgreSQL, MySQL/Trilogy, SQLite — shared or separate database** · **No vendor lock-in**
 
 [Full Documentation](https://anjanj.github.io/rails_error_dashboard/) · [Live Demo](https://rails-error-dashboard.anjan.dev) · [RubyGems](https://rubygems.org/gems/rails_error_dashboard)
 
@@ -599,6 +599,37 @@ end
 **Multi-App Support** — Track errors from multiple Rails apps in a single shared database. Auto-detects app name, supports per-app filtering. [Multi-App guide →](docs/MULTI_APP_PERFORMANCE.md)
 
 **OpenTelemetry Export** — Emit error-capture operations as OTel spans to Datadog, Honeycomb, or Jaeger. Add `gem "opentelemetry-api"` and set `config.enable_otel_export = true`. See [OpenTelemetry Export](#opentelemetry-export--emit-gem-operations-as-spans) above for full options.
+
+---
+
+## FAQ
+
+**Does Rails Error Dashboard support a separate database for errors?**
+Yes. You can store errors in your app's existing database (shared) **or** in a dedicated, isolated database (separate). Set `config.use_separate_database = true` (or `USE_SEPARATE_ERROR_DB=true`) and point it at a separate connection — the engine routes all of its tables through `connects_to`, keeping error data fully isolated from your app data. Both modes are first-class and covered by the [Database Options guide](docs/guides/DATABASE_OPTIONS.md).
+
+**Which databases does it work with?**
+SQLite, PostgreSQL, and MySQL/Trilogy — in either shared or separate-database mode.
+
+**Is this a self-hosted alternative to Sentry?**
+Yes. It runs entirely inside your own Rails process — no external services, no SDK calling out, no per-event pricing. Error data never leaves your infrastructure.
+
+**Does it capture local variables like Sentry?**
+Yes — local **and** instance variables at the moment the exception is raised, via `TracePoint(:raise)`, with sensitive-data filtering and configurable limits. This is opt-in and a capability Sentry charges extra for.
+
+**Will a flood of errors take down my app?**
+No. Storm protection (a circuit breaker with adaptive sampling, **ON by default**) makes the gem degrade itself first during error floods — occurrence counts stay exact while it sheds the expensive work. Measured hot-path overhead is ~2.4µs/error.
+
+**Does it work with my background jobs?**
+Yes — it auto-detects and supports Sidekiq, SolidQueue, and GoodJob, and can log errors asynchronously through any of them.
+
+**Does it work with my authentication?**
+Yes — HTTP Basic Auth out of the box, or a custom `authenticate_with` lambda that integrates with Devise, Warden, or session-based auth.
+
+**Can it track more than one app?**
+Yes — multi-app support tracks errors from multiple Rails apps in one dashboard with per-app filtering.
+
+**What Rails and Ruby versions are supported?**
+Rails 7.0–8.1 and Ruby 3.2–4.0.
 
 ---
 

--- a/rails_error_dashboard.gemspec
+++ b/rails_error_dashboard.gemspec
@@ -6,13 +6,24 @@ Gem::Specification.new do |spec|
   spec.authors     = [ "Anjan Jagirdar" ]
   spec.email       = [ "anjan.jagirdar@gmail.com" ]
   spec.homepage    = "https://AnjanJ.github.io/rails_error_dashboard"
-  spec.summary     = "Self-hosted error tracking and exception monitoring for Rails. Free, forever."
+  spec.summary     = "Self-hosted error tracking for Rails — local variables, system health, " \
+                     "separate or shared database. A free, open-source Sentry alternative."
   spec.description = "Own your errors. Own your stack. A fully open-source, self-hosted error tracking " \
-                     "Rails engine for solo founders, indie hackers, and small teams. Exception monitoring " \
-                     "with beautiful dashboard UI, multi-channel notifications (Slack, Email, Discord, " \
-                     "PagerDuty), platform detection (iOS/Android/Web/API), advanced analytics, workflow " \
-                     "management, and cause chain capture. A self-hosted Sentry alternative with 5-minute " \
-                     "setup that works out-of-the-box. Production error monitoring for Rails 7.0-8.1. " \
+                     "Rails engine — a free Sentry alternative that runs entirely inside your own " \
+                     "process, with no external services and zero recurring cost. " \
+                     "Captures what SaaS tools charge extra for: local and instance variables at the " \
+                     "moment of failure (via TracePoint), exception cause chains, swallowed-exception " \
+                     "detection, breadcrumbs, and system-health snapshots (GC, memory, threads, " \
+                     "connection pool, Puma). Plus N+1 query detection, storm protection (a circuit " \
+                     "breaker that shields your app from error floods, ON by default), multi-app " \
+                     "support, error sampling, and async logging via Sidekiq, SolidQueue, or GoodJob. " \
+                     "Runs on SQLite, PostgreSQL, or MySQL/Trilogy — in your app's existing database " \
+                     "or an isolated separate error database. Beautiful dashboard UI (dark/light), " \
+                     "multi-channel notifications (Slack, Email, Discord, PagerDuty, webhooks), " \
+                     "workflow management, advanced analytics, platform detection (iOS/Android/Web/API), " \
+                     "and two-way issue sync with GitHub, GitLab, Codeberg, and Linear. Also: LLM " \
+                     "observability, AI-powered debugging help, and OpenTelemetry span export. " \
+                     "5-minute setup, works out-of-the-box. Rails 7.0-8.1, Ruby 3.2-4.0. " \
                      "BETA: API may change before v1.0.0. " \
                      "Live demo: https://rails-error-dashboard.anjan.dev (gandalf/youshallnotpass)"
   spec.license     = "MIT"


### PR DESCRIPTION
## Why

The RubyGems `description` named only **4 of ~50** real capabilities. Search engines and AI assistants build their answers from the text we publish and backfill the gaps with competitor facts — most visibly, claiming the gem can't use a **separate error database** (it can, and always has, via `use_separate_database` + `connects_to`).

## Changes

- **gemspec** `summary` + `description` rewritten to name the major differentiators (local/instance variable capture, system health, swallowed-exception detection, storm protection, multi-app, async logging, LLM observability, OTel export, four-provider issue sync) and to state plainly that errors live in a **shared or separate** database across SQLite / PostgreSQL / MySQL-Trilogy. Adds Ruby 3.2–4.0. Gem builds clean.
- **README** tagline now says "shared or separate database"; new **FAQ** section (Q&A-shaped for AI retrieval) leads with the separate-database question, plus Sentry-alternative / local-variable / storm-protection / jobs / auth / multi-app / version questions.

## Verification

Every claim verified against `configuration.rb` / source before writing. `gem build` succeeds; RuboCop clean; no behavioral changes.

A fully fact-checked competitor comparison article (every competitor claim verified against live sources on 2026-06-22) was also drafted to `seo/drafts/` (gitignored) for separate review — not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)