### PR TITLE
fix(rack-attack): surface a missing rack-attack gem instead of failing silently

### DIFF
--- a/_getting_started/features.md
+++ b/_getting_started/features.md
@@ -820,16 +820,19 @@ The page at `/errors/diagnostic_dumps` shows:
 
 ## Rack Attack Event Tracking (v0.4.0)
 
-**⚙️ Optional Feature** - Rack Attack tracking is disabled by default. **Requires breadcrumbs to be enabled.** Enable it to track Rack::Attack security events:
+**⚙️ Optional Feature** - Rack Attack tracking is disabled by default. Requires the `rack-attack` gem to be installed and configured in your app. Enable it to track Rack::Attack security events:
 
 ```ruby
-config.enable_breadcrumbs = true
 config.enable_rack_attack_tracking = true
 ```
 
 ### How It Works
 
-Subscribes to Rack::Attack's ActiveSupport::Notifications events and records them as breadcrumbs. When an error occurs after a throttle or blocklist event, the breadcrumbs show the security context — revealing whether rate limiting or blocking contributed to the error.
+Subscribes to Rack::Attack's ActiveSupport::Notifications events and persists them to their own table, independently of error capture. This matters because a throttled request returns HTTP 429 without raising — so these events would never be recorded if they depended on an error occurring.
+
+Events are aggregated into hourly buckets by rule, match type, discriminator, and path, so a rate-limit flood collapses into a handful of rows rather than one insert per request.
+
+If breadcrumbs are also enabled, the event is additionally recorded on the request's activity trail, so it shows up as security context on the error detail page when an error does occur in the same request.
 
 ### Tracked Events
 

--- a/_guides/configuration.md
+++ b/_guides/configuration.md
@@ -895,16 +895,17 @@ Trigger via dashboard button or `rails error_dashboard:diagnostic_dump NOTE="dep
 
 ## Rack Attack Event Tracking (v0.4.0)
 
-Track Rack::Attack throttle, blocklist, and track events as breadcrumbs. Requires breadcrumbs to be enabled.
+Record Rack::Attack throttle, blocklist, and track events to their own table, aggregated hourly. Requires the `rack-attack` gem to be installed and configured in your app. Breadcrumbs are **not** required.
 
 ```ruby
 RailsErrorDashboard.configure do |config|
-  config.enable_breadcrumbs = true              # Required dependency
   config.enable_rack_attack_tracking = true
+  config.rack_attack_max_cache_size = 1000      # Buffered keys per thread (LRU)
+  config.rack_attack_flush_interval = 60        # Seconds between DB flushes
 end
 ```
 
-Auto-disabled with warning if breadcrumbs are not enabled. Dashboard page at `/errors/rack_attack_summary`.
+If `rack-attack` is not loaded, a startup warning is logged and no events are recorded. Enabling breadcrumbs as well adds the event to the activity trail on error detail pages. Dashboard page at `/errors/rack_attack_summary`.
 
 ---
 

--- a/app/controllers/rails_error_dashboard/errors_controller.rb
+++ b/app/controllers/rails_error_dashboard/errors_controller.rb
@@ -490,6 +490,10 @@ module RailsErrorDashboard
         return
       end
 
+      # Distinguishes "gem not installed" from "installed but no rules matched"
+      # in the empty state — both otherwise render an identical blank page.
+      @rack_attack_missing = !defined?(::Rack::Attack)
+
       days = days_param(default: 30)
       @days = days
       result = Queries::RackAttackSummary.call(days, application_id: @current_application_id)

--- a/app/views/rails_error_dashboard/errors/rack_attack_summary.html.erb
+++ b/app/views/rails_error_dashboard/errors/rack_attack_summary.html.erb
@@ -22,11 +22,21 @@
 
   <% if @unique_rules == 0 %>
     <div class="red-empty-state">
-      <i class="bi bi-shield-check display-1 text-success mb-3"></i>
-      <div class="red-empty-state-title">No Rate Limit Events Found</div>
-      <p class="text-muted">
-        No Rack Attack throttle, blocklist, or track events were recorded over the last <%= @days %> days.
-      </p>
+      <% if @rack_attack_missing %>
+        <i class="bi bi-exclamation-triangle display-1 text-warning mb-3"></i>
+        <div class="red-empty-state-title">Rack Attack Is Not Installed</div>
+        <p class="text-muted">
+          Tracking is enabled, but the <code>rack-attack</code> gem is not loaded in this
+          application — so no events can be recorded. Add it to your Gemfile and configure
+          at least one rule, then events will appear here.
+        </p>
+      <% else %>
+        <i class="bi bi-shield-check display-1 text-success mb-3"></i>
+        <div class="red-empty-state-title">No Rate Limit Events Found</div>
+        <p class="text-muted">
+          No Rack Attack throttle, blocklist, or track events were recorded over the last <%= @days %> days.
+        </p>
+      <% end %>
       <div class="card mx-auto" style="max-width: 500px;">
         <div class="card-body text-start">
           <h6>How Rack Attack tracking works:</h6>

--- a/app/views/rails_error_dashboard/errors/settings.html.erb
+++ b/app/views/rails_error_dashboard/errors/settings.html.erb
@@ -144,7 +144,7 @@
       icon: "bi-broadcast",
       color: "info",
       settings: {
-        enable_rack_attack_tracking: { label: "Rack Attack Tracking", description: "Track throttle/blocklist events as breadcrumbs", type: :boolean },
+        enable_rack_attack_tracking: { label: "Rack Attack Tracking", description: "Record throttle/blocklist events to their own table", type: :boolean },
         enable_actioncable_tracking: { label: "ActionCable Tracking", description: "Track WebSocket channel events as breadcrumbs", type: :boolean },
         enable_activestorage_tracking: { label: "ActiveStorage Tracking", description: "Track uploads/downloads/deletes as breadcrumbs", type: :boolean }
       }

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -886,16 +886,19 @@ The page at `/errors/diagnostic_dumps` shows:
 
 ## Rack Attack Event Tracking (v0.4.0)
 
-**⚙️ Optional Feature** - Rack Attack tracking is disabled by default. **Requires breadcrumbs to be enabled.** Enable it to track Rack::Attack security events:
+**⚙️ Optional Feature** - Rack Attack tracking is disabled by default. Requires the `rack-attack` gem to be installed and configured in your app. Enable it to track Rack::Attack security events:
 
 ```ruby
-config.enable_breadcrumbs = true
 config.enable_rack_attack_tracking = true
 ```
 
 ### How It Works
 
-Subscribes to Rack::Attack's ActiveSupport::Notifications events and records them as breadcrumbs. When an error occurs after a throttle or blocklist event, the breadcrumbs show the security context — revealing whether rate limiting or blocking contributed to the error.
+Subscribes to Rack::Attack's ActiveSupport::Notifications events and persists them to their own table, independently of error capture. This matters because a throttled request returns HTTP 429 without raising — so these events would never be recorded if they depended on an error occurring.
+
+Events are aggregated into hourly buckets by rule, match type, discriminator, and path, so a rate-limit flood collapses into a handful of rows rather than one insert per request.
+
+If breadcrumbs are also enabled, the event is additionally recorded on the request's activity trail, so it shows up as security context on the error detail page when an error does occur in the same request.
 
 ### Tracked Events
 
@@ -909,7 +912,9 @@ The page at `/errors/rack_attack_summary` shows event breakdown with time range 
 
 ### Safety
 
-- **Auto-disabled** — If breadcrumbs are not enabled, Rack Attack tracking is automatically disabled with a warning (no crash)
+- **Degrades cleanly** — If the `rack-attack` gem is not loaded, the subscriber never registers and a startup warning is logged (no crash). The dashboard page says so explicitly instead of showing a blank report
+- **Zero I/O in the request path** — Events are counted in a thread-local buffer and flushed to the database asynchronously, so a rate-limit flood never turns into a write flood
+- **Bounded memory** — LRU eviction caps buffered keys per thread, so an attacker rotating IPs cannot grow the buffer without limit
 - **Zero integration cost** — Rack::Attack already emits AS::Notifications events; this just subscribes to them
 
 ---

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -929,16 +929,17 @@ Trigger via dashboard button or `rails error_dashboard:diagnostic_dump NOTE="dep
 
 ## Rack Attack Event Tracking (v0.4.0)
 
-Track Rack::Attack throttle, blocklist, and track events as breadcrumbs. Requires breadcrumbs to be enabled.
+Record Rack::Attack throttle, blocklist, and track events to their own table, aggregated hourly. Requires the `rack-attack` gem to be installed and configured in your app. Breadcrumbs are **not** required.
 
 ```ruby
 RailsErrorDashboard.configure do |config|
-  config.enable_breadcrumbs = true              # Required dependency
   config.enable_rack_attack_tracking = true
+  config.rack_attack_max_cache_size = 1000      # Buffered keys per thread (LRU)
+  config.rack_attack_flush_interval = 60        # Seconds between DB flushes
 end
 ```
 
-Auto-disabled with warning if breadcrumbs are not enabled. Dashboard page at `/errors/rack_attack_summary`.
+If `rack-attack` is not loaded, a startup warning is logged and no events are recorded. Enabling breadcrumbs as well adds the event to the activity trail on error detail pages. Dashboard page at `/errors/rack_attack_summary`.
 
 ---
 

--- a/lib/rails_error_dashboard/configuration.rb
+++ b/lib/rails_error_dashboard/configuration.rb
@@ -590,6 +590,16 @@ module RailsErrorDashboard
         if rack_attack_flush_interval && rack_attack_flush_interval < 1
           errors << "rack_attack_flush_interval must be at least 1 (got: #{rack_attack_flush_interval})"
         end
+
+        # Warn rather than auto-disable: validation may run before the host's
+        # Rack::Attack initializer has loaded, so a missing constant here does
+        # not prove it will still be missing at after_initialize (when the
+        # subscriber actually registers). Auto-disabling would break that case.
+        unless defined?(::Rack::Attack)
+          warnings << "enable_rack_attack_tracking is enabled but the rack-attack gem " \
+                      "does not appear to be loaded. No events will be recorded until " \
+                      "Rack::Attack is installed and configured."
+        end
       end
 
       # Validate actioncable tracking requires breadcrumbs

--- a/spec/lib/rails_error_dashboard/configuration_spec.rb
+++ b/spec/lib/rails_error_dashboard/configuration_spec.rb
@@ -500,6 +500,33 @@ RSpec.describe RailsErrorDashboard::Configuration do
 
       expect { config.validate! }.not_to raise_error
     end
+
+    # The rack-attack gem is not a dependency and is not loaded in the suite,
+    # so ::Rack::Attack is genuinely undefined here.
+    context "when the rack-attack gem is not loaded" do
+      it "logs a warning without raising" do
+        config.enable_rack_attack_tracking = true
+
+        expect(Rails.logger).to receive(:warn).with(/rack-attack gem does not appear to be loaded/)
+
+        expect { config.validate! }.not_to raise_error
+      end
+
+      it "does not auto-disable tracking" do
+        config.enable_rack_attack_tracking = true
+        config.validate!
+
+        expect(config.enable_rack_attack_tracking).to be true
+      end
+
+      it "stays silent when tracking is disabled" do
+        config.enable_rack_attack_tracking = false
+
+        expect(Rails.logger).not_to receive(:warn).with(/rack-attack/)
+
+        config.validate!
+      end
+    end
   end
 
   describe "rack_attack tracking defaults" do

--- a/spec/requests/rack_attack_summary_spec.rb
+++ b/spec/requests/rack_attack_summary_spec.rb
@@ -76,9 +76,27 @@ RSpec.describe "Rack Attack Summary page", type: :request do
         expect(response).to have_http_status(:ok)
       end
 
-      it "shows empty state when no rack_attack events exist" do
-        get "/error_dashboard/errors/rack_attack_summary"
-        expect(response.body).to include("No Rate Limit Events Found")
+      # The empty state distinguishes "gem not installed" from "installed but
+      # no rules matched" — both otherwise render an identical blank page,
+      # which is the ambiguity that made issue #143 hard to diagnose.
+      context "when the rack-attack gem is not loaded" do
+        it "says the gem is missing rather than reporting no events" do
+          get "/error_dashboard/errors/rack_attack_summary"
+
+          expect(response.body).to include("Rack Attack Is Not Installed")
+          expect(response.body).not_to include("No Rate Limit Events Found")
+        end
+      end
+
+      context "when the rack-attack gem is loaded" do
+        before { stub_const("Rack::Attack", Class.new) }
+
+        it "shows the no-events empty state" do
+          get "/error_dashboard/errors/rack_attack_summary"
+
+          expect(response.body).to include("No Rate Limit Events Found")
+          expect(response.body).not_to include("Rack Attack Is Not Installed")
+        end
       end
 
       it "shows recorded rack_attack events" do


### PR DESCRIPTION
## What

Enabling `enable_rack_attack_tracking` without the `rack-attack` gem installed was safe but undiagnosable. This makes the failure visible in two places, and corrects docs that predated #143.

## Why

The subscriber is gated on `defined?(Rack::Attack)` (`engine.rb:84`), so with no gem it silently never registers. The Rate Limits page then rendered the *same* "No Rate Limit Events Found" empty state it shows when the gem **is** installed and simply no rule has matched yet.

Three states rendered identically:

1. `rack-attack` not installed → subscriber never registered
2. Installed, but no rule has ever matched → genuinely nothing to show
3. Rules matched within the last flush interval → buffered, not yet written

That ambiguity is what made #143 hard to report in the first place — a permanently blank page with no way to tell "not wired up" from "nothing to show". The sibling flags (`enable_actioncable_tracking`, `enable_activestorage_tracking`) already warn when their prerequisite is missing; this one did not.

## How

**Startup warning** — `Configuration#validate!` logs when tracking is on but `::Rack::Attack` is undefined.

It **warns rather than auto-disables**, deliberately. Validation can run before the host's Rack::Attack initializer, so a missing constant at `validate!` time does not prove it will still be missing at `after_initialize`, when the subscriber actually registers. Auto-disabling would break that ordering — which is why this diverges from the auto-disable pattern used by the ActionCable/ActiveStorage flags.

**Empty state** — the page now says the gem is not loaded instead of reporting zero events. The controller sets `@rack_attack_missing` so the view isn't probing constants itself.

**Docs** — several files still claimed breadcrumbs were a required dependency and that tracking auto-disables without them. Neither has been true since #143 moved events to their own table. Fixed in `docs/FEATURES.md`, `docs/guides/CONFIGURATION.md`, their Jekyll mirrors, and the settings-page description that still called this breadcrumb storage.

## Not changed

Still opt-in, still a no-op without the gem, still zero runtime cost when disabled. No capture-path code touched.

## Test plan

- RSpec: **3640 examples, 0 failures** (+4)
- RuboCop clean on all changed Ruby files
- Both empty-state branches covered. The gem-present case uses `stub_const`, since `rack-attack` is not a dependency and is absent from the suite — which also means the gem-missing branch is the suite's default state
- Chaos tests skipped locally (no capture-path changes); CI covers the rest

🤖 Generated with [Claude Code](https://claude.com/claude-code)