### PR TITLE
fix(dashboard): render pagination in the dashboard's own locale

### DIFF
--- a/_guides/configuration.md
+++ b/_guides/configuration.md
@@ -54,6 +54,19 @@ Complete reference of all 60+ configuration options with defaults, types, and de
 | `database` | Symbol/String | `nil` | Database connection name (nil = primary database) |
 | `use_separate_database` | Boolean | `false` | Use separate database for errors (ENV: `USE_SEPARATE_ERROR_DB`) |
 
+### Dashboard UI
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `accent_color` | Symbol | `:crimson` | Dashboard accent colour — `:crimson`, `:ruby`, `:ember`, `:violet` |
+| `dashboard_locale` | String | `"en"` | Locale the dashboard renders in, independent of the host app's locale. Currently affects Pagy pagination labels; the rest of the UI is English-only. Unknown or wrong-cased values fall back to `"en"` |
+
+The dashboard sets its own locale for the duration of each request and restores
+the previous value afterwards, so it neither inherits the host app's locale nor
+leaks its own back into the host. This matters because Pagy stores its locale in
+a thread-local it never resets — without this, a dashboard request landing on a
+recycled Puma thread would render in whatever language the host app last used.
+
 ### Notifications - Slack
 
 | Option | Type | Default | Description |

--- a/app/controllers/rails_error_dashboard/application_controller.rb
+++ b/app/controllers/rails_error_dashboard/application_controller.rb
@@ -12,6 +12,16 @@ module RailsErrorDashboard
 
     protect_from_forgery with: :exception
 
+    # Render pagination in the dashboard's own locale, not the host app's.
+    #
+    # Pagy stores its locale in Thread.current[:pagy_locale] and never resets it
+    # (pagy 43.6.1, modules/i18n/i18n.rb:24-31 — the "for the duration of a single
+    # request" comment is aspirational; nothing in the gem enforces it). A host app
+    # that sets a per-request locale leaves that value on the Puma thread, so a
+    # dashboard request landing on a recycled thread inherits whatever language the
+    # host last used — Russian on one refresh, Portuguese on the next (issue #148).
+    around_action :with_dashboard_locale
+
     # CRITICAL: Ensure dashboard errors never break the app
     # Catch all exceptions and render user-friendly error page
     # NOTE: rescue_from is checked in reverse declaration order (last = highest priority).
@@ -59,6 +69,49 @@ module RailsErrorDashboard
     end
 
     private
+
+    # Set Pagy's locale for this request and restore whatever was there before.
+    #
+    # Two details are load-bearing:
+    #
+    # 1. The previous value is read from Thread.current directly, NOT from
+    #    Pagy::I18n.locale. The getter coerces nil to "en", so restoring through
+    #    it would stamp "en" onto a thread that started clean — making the
+    #    dashboard a source of the very leak it is fixing.
+    # 2. around_action + ensure, not before_action. A before_action would strand
+    #    the dashboard's locale on the thread for the host app's next request.
+    #    The ensure also covers the rescue_from handlers above, which still
+    #    render through the view layer.
+    def with_dashboard_locale
+      previous = Thread.current[:pagy_locale]
+      Pagy::I18n.locale = dashboard_pagy_locale
+      yield
+    ensure
+      Thread.current[:pagy_locale] = previous
+    end
+
+    def dashboard_pagy_locale
+      configured = RailsErrorDashboard.configuration.dashboard_locale.to_s.strip
+      return "en" if configured.empty?
+
+      self.class.resolved_pagy_locales[configured] ||= resolve_pagy_locale(configured)
+    rescue StandardError
+      "en"
+    end
+
+    # Pagy looks its dictionary up by exact filename AND by an exact top-level
+    # key inside that YAML, so "EN" finds en.yml but then reads a nil dictionary
+    # and raises mid-render. Match the shipped filenames case-insensitively and
+    # fall back to English for anything Pagy cannot serve.
+    def resolve_pagy_locale(configured)
+      available = Pagy::I18n.pathnames.flat_map { |dir| Dir.glob(dir.join("*.yml")) }
+                              .map { |path| File.basename(path, ".yml") }
+      available.find { |locale| locale.casecmp?(configured) } || "en"
+    end
+
+    def self.resolved_pagy_locales
+      @resolved_pagy_locales ||= {}
+    end
 
     def render_dashboard_error(icon:, title:, message:, detail: nil, icon_style: nil, status: :internal_server_error)
       set_common_view_variables

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -54,6 +54,19 @@ Complete reference of all 60+ configuration options with defaults, types, and de
 | `database` | Symbol/String | `nil` | Database connection name (nil = primary database) |
 | `use_separate_database` | Boolean | `false` | Use separate database for errors (ENV: `USE_SEPARATE_ERROR_DB`) |
 
+### Dashboard UI
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `accent_color` | Symbol | `:crimson` | Dashboard accent colour — `:crimson`, `:ruby`, `:ember`, `:violet` |
+| `dashboard_locale` | String | `"en"` | Locale the dashboard renders in, independent of the host app's locale. Currently affects Pagy pagination labels; the rest of the UI is English-only. Unknown or wrong-cased values fall back to `"en"` |
+
+The dashboard sets its own locale for the duration of each request and restores
+the previous value afterwards, so it neither inherits the host app's locale nor
+leaks its own back into the host. This matters because Pagy stores its locale in
+a thread-local it never resets — without this, a dashboard request landing on a
+recycled Puma thread would render in whatever language the host app last used.
+
 ### Notifications - Slack
 
 | Option | Type | Default | Description |

--- a/lib/rails_error_dashboard/configuration.rb
+++ b/lib/rails_error_dashboard/configuration.rb
@@ -222,6 +222,11 @@ module RailsErrorDashboard
     # Dashboard UI appearance
     attr_accessor :accent_color  # :crimson (default), :ruby, :ember, :violet
 
+    # Locale the dashboard renders in, independent of the host app's locale.
+    # Currently applies to Pagy pagination labels — the rest of the dashboard
+    # UI is not yet translated (default: "en").
+    attr_accessor :dashboard_locale
+
     # LLM-powered AI help (disabled unless provider and API key are configured)
     attr_accessor :llm_provider              # :openai or :anthropic
     attr_accessor :llm_api_key               # String or lambda/proc
@@ -433,6 +438,7 @@ module RailsErrorDashboard
 
       # Dashboard UI
       @accent_color = :crimson  # :crimson, :ruby, :ember, :violet
+      @dashboard_locale = "en"  # Pagy pagination labels; rest of the UI is English-only
 
       # LLM-powered AI help defaults - OFF until provider and API key are configured
       @llm_provider = ENV["RED_LLM_PROVIDER"]&.to_sym

--- a/spec/requests/dashboard_locale_spec.rb
+++ b/spec/requests/dashboard_locale_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Regression for issue #148: the dashboard rendered Pagy labels in whatever
+# language the host app last used.
+#
+# Pagy keeps its locale in Thread.current[:pagy_locale] and never resets it
+# (pagy 43.6.1, modules/i18n/i18n.rb:24-31). A host app that assigns a locale
+# per request leaves it on the Puma thread, so a dashboard request landing on a
+# recycled thread inherited it — Russian on one refresh, Portuguese on the next.
+RSpec.describe "Dashboard locale isolation", type: :request do
+  let!(:application) { create(:application) }
+
+  before do
+    RailsErrorDashboard.configuration.authenticate_with = -> { true }
+    # user_impact only renders its Pagy info line when there are ranked rows,
+    # which requires errors attributed to a user.
+    create_list(:error_log, 3, :with_user, application: application)
+  end
+
+  after do
+    RailsErrorDashboard.configuration.authenticate_with = nil
+    RailsErrorDashboard.configuration.dashboard_locale = "en"
+    Thread.current[:pagy_locale] = nil
+  end
+
+  describe "when the host app has left a locale on the thread" do
+    it "renders pagination in English rather than the host's locale" do
+      Thread.current[:pagy_locale] = "ru"
+
+      get "/error_dashboard/errors/user_impact"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Displaying")
+      expect(response.body).not_to include("Всего")
+    end
+
+    it "restores the host's locale after the request" do
+      Thread.current[:pagy_locale] = "ru"
+
+      get "/error_dashboard/errors/user_impact"
+
+      expect(Thread.current[:pagy_locale]).to eq("ru")
+    end
+
+    # The previous value must be read from Thread.current, not from
+    # Pagy::I18n.locale — the getter coerces nil to "en", so restoring through
+    # it would dirty a thread that started clean.
+    it "leaves a clean thread clean" do
+      Thread.current[:pagy_locale] = nil
+
+      get "/error_dashboard/errors/user_impact"
+
+      expect(Thread.current[:pagy_locale]).to be_nil
+    end
+  end
+
+  describe "dashboard_locale configuration" do
+    it "defaults to English" do
+      expect(RailsErrorDashboard.configuration.dashboard_locale).to eq("en")
+    end
+
+    it "renders pagination in the configured locale" do
+      RailsErrorDashboard.configuration.dashboard_locale = "fr"
+
+      get "/error_dashboard/errors/user_impact"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Affichage")
+    end
+
+    # "EN" passes Pagy's LOCALE_PATTERN, finds en.yml, then reads a nil
+    # dictionary because the YAML's top-level key is lowercase — raising
+    # NoMethodError mid-render on every dashboard page.
+    it "accepts a wrong-cased locale without raising" do
+      RailsErrorDashboard.configuration.dashboard_locale = "EN"
+
+      get "/error_dashboard/errors/user_impact"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Displaying")
+    end
+
+    it "falls back to English for a locale Pagy does not ship" do
+      RailsErrorDashboard.configuration.dashboard_locale = "not-a-locale"
+
+      get "/error_dashboard/errors/user_impact"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Displaying")
+    end
+
+    it "falls back to English when set to nil" do
+      RailsErrorDashboard.configuration.dashboard_locale = nil
+
+      get "/error_dashboard/errors/user_impact"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Displaying")
+    end
+  end
+end


### PR DESCRIPTION
Fixes #148.

## The bug

The dashboard rendered Pagy labels in whatever language the host app last used — Russian on one refresh, Portuguese on the next.

## Root cause

Pagy stores its locale in a thread-local it **never resets** (`pagy-43.6.1/lib/pagy/modules/i18n/i18n.rb:24-31`):

```ruby
# Set a valid locale or nil for the duration of a single request. Avoid errors/logging.
def locale=(value)
  Thread.current[:pagy_locale] = value.to_s[LOCALE_PATTERN]
end

def locale
  Thread.current[:pagy_locale] || 'en'
end
```

That comment is aspirational — there is no `around_action`, railtie hook, or `ensure` anywhere in the gem. So under Puma:

1. Host app request on thread A sets `Pagy::I18n.locale = "ru"`
2. Thread A returns to the pool still holding `"ru"`
3. A dashboard request lands on thread A → renders Russian
4. Next one lands on thread B, which last served `pt` → Portuguese

The language is a function of *which pooled thread picked up the request*, which is why it looked random and changed on refresh.

## Reproduction

Deterministic, no Rails app needed — set the locale on a thread, then render `info_tag` on that same thread:

```
host set ru  -> Всего 100 записей, показаны с 1 по 25
host set pt  -> Mostrando itens 1-25 de um total de 100
host set fr  -> Affichage des éléments 1 à 25 sur 100 au total
host set es  -> Mostrando ítems 1-25 de 100 en total
```

Identical dashboard code, four languages.

## The fix

Pagy 43 has **no per-call locale option** (verified across every helper signature), so set-and-restore around the request is the only correct approach. Two details are load-bearing:

- **`around_action`, not `before_action`.** A `before_action` would strand the dashboard's locale on the thread for the host app's next request — the same leak pointing the other way. The `ensure` also covers the `rescue_from` handlers, which still render through the view layer.
- **Read the previous value from `Thread.current`, not `Pagy::I18n.locale`.** The getter coerces `nil` → `"en"`, so restoring through it would stamp `"en"` onto a thread that started clean, making the dashboard a source of the very leak it fixes.

## `config.dashboard_locale`

Added (default `"en"`) rather than hardcoding English, so the mechanism is already in place for translating the rest of the dashboard later. Today it only affects Pagy labels; every other string in the UI is still English.

Resolution is defensive. An unknown lowercase tag (`"xx"`) warns and falls back inside Pagy, but a wrong-cased one (`"EN"`) passes Pagy's `LOCALE_PATTERN`, finds `en.yml`, then reads a nil dictionary because the YAML's top-level key is lowercase — raising `NoMethodError` mid-render on **every** dashboard page. Values are matched case-insensitively against the shipped dictionaries and fall back to `"en"`, so a config typo cannot take the dashboard down.

## Note for the reporter

The workaround in #148 has this same bug in the opposite direction — the admin controller sets `Pagy::I18n.locale` in a `before_action` and never restores it, leaking `"en"` into the public site's threads. The `around_action`/`ensure` pattern here fixes that class of bug.

## Test plan

- RSpec: **3648 examples, 0 failures** (+8)
- RuboCop: 414 files, no offenses
- Verified the two core specs **fail** with the `around_action` removed and pass with it, including the exact reported symptom
- Locale resolution checked against `nil`, `""`, `"  "`, `en`, `EN`, `fr`, `FR`, `ru`, `pt-BR`, `pt-br`, `PT-BR`, `zh-CN`, `:fr`, `"xx"`, `"not-a-locale"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)