### PR TITLE
fix(security): authenticate every dashboard controller, not just ErrorsController

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,11 +17,25 @@ If you're using an older version and discover a security issue, please upgrade t
 
 ### How to Report
 
-We use GitHub's built-in Security Advisories for private vulnerability reporting:
+**Either of these works. Both are private — pick whichever is easier for you.**
 
-1. Go to the [Security tab](https://github.com/AnjanJ/rails_error_dashboard/security/advisories/new)
-2. Click "Report a vulnerability"
-3. Fill out the form with as much detail as possible
+**1. GitHub private vulnerability reporting (preferred)**
+
+1. Go to [Report a vulnerability](https://github.com/AnjanJ/rails_error_dashboard/security/advisories/new)
+2. Fill out the form with as much detail as possible
+
+The report is visible only to you and the maintainer. It also gives us a place
+to work through the fix together and to publish an advisory crediting you.
+
+**2. Email — [security@anjan.dev](mailto:security@anjan.dev)**
+
+If you would rather not use GitHub, or the link above is not working for you
+for any reason, email us directly. A plain description is fine; do not let
+formatting slow you down.
+
+**If one channel does not work, use the other rather than filing a public
+issue.** If neither works, that is a bug in this policy — say so in an email
+and we will fix it.
 
 ### What to Include in Your Report
 

--- a/app/controllers/rails_error_dashboard/application_controller.rb
+++ b/app/controllers/rails_error_dashboard/application_controller.rb
@@ -1,5 +1,17 @@
 module RailsErrorDashboard
   class ApplicationController < ActionController::Base
+    # Authenticate EVERY dashboard controller, not just the ones that remember
+    # to ask. This filter used to live on ErrorsController, which meant a new
+    # controller inherited no protection at all — LocalesController (the P5-T1
+    # language picker) shipped unauthenticated for exactly that reason, and an
+    # unauthenticated POST reached controller code and 500'd instead of being
+    # refused with a 401.
+    #
+    # Declaring it here inverts the default: a controller is protected unless
+    # it explicitly opts out with skip_before_action, which is a visible,
+    # reviewable act rather than an omission nobody notices.
+    before_action :authenticate_dashboard_user!
+
     include Pagy::Method
 
     # Enable features that are disabled in API-only mode
@@ -186,6 +198,46 @@ module RailsErrorDashboard
       # those callbacks, so reuse their result instead of querying a second time.
       # Tracked by a flag rather than the value, since the common case is nil.
       @storm_banner_event = Queries::StormHistory.banner_event unless @storm_banner_loaded
+    end
+
+    def authenticate_dashboard_user!
+      auth_lambda = RailsErrorDashboard.configuration.authenticate_with
+
+      if auth_lambda
+        authenticate_with_lambda(auth_lambda)
+      else
+        authenticate_with_basic_auth
+      end
+    end
+
+    def authenticate_with_lambda(auth_lambda)
+      authorized = begin
+        instance_exec(&auth_lambda)
+      rescue => e
+        Rails.logger.error(
+          "[RailsErrorDashboard] authenticate_with lambda raised #{e.class}: #{e.message}"
+        )
+        false
+      end
+
+      return if performed?
+
+      unless authorized
+        render plain: "Access Denied", status: :forbidden
+      end
+    end
+
+    def authenticate_with_basic_auth
+      authenticate_or_request_with_http_basic do |username, password|
+        ActiveSupport::SecurityUtils.secure_compare(
+          username,
+          RailsErrorDashboard.configuration.dashboard_username
+        ) &
+        ActiveSupport::SecurityUtils.secure_compare(
+          password,
+          RailsErrorDashboard.configuration.dashboard_password
+        )
+      end
     end
   end
 end

--- a/app/controllers/rails_error_dashboard/errors_controller.rb
+++ b/app/controllers/rails_error_dashboard/errors_controller.rb
@@ -801,45 +801,5 @@ module RailsErrorDashboard
       @storm_banner_loaded = true
       @storm_banner_event = Queries::StormHistory.banner_event
     end
-
-    def authenticate_dashboard_user!
-      auth_lambda = RailsErrorDashboard.configuration.authenticate_with
-
-      if auth_lambda
-        authenticate_with_lambda(auth_lambda)
-      else
-        authenticate_with_basic_auth
-      end
-    end
-
-    def authenticate_with_lambda(auth_lambda)
-      authorized = begin
-        instance_exec(&auth_lambda)
-      rescue => e
-        Rails.logger.error(
-          "[RailsErrorDashboard] authenticate_with lambda raised #{e.class}: #{e.message}"
-        )
-        false
-      end
-
-      return if performed?
-
-      unless authorized
-        render plain: "Access Denied", status: :forbidden
-      end
-    end
-
-    def authenticate_with_basic_auth
-      authenticate_or_request_with_http_basic do |username, password|
-        ActiveSupport::SecurityUtils.secure_compare(
-          username,
-          RailsErrorDashboard.configuration.dashboard_username
-        ) &
-        ActiveSupport::SecurityUtils.secure_compare(
-          password,
-          RailsErrorDashboard.configuration.dashboard_password
-        )
-      end
-    end
   end
 end

--- a/spec/requests/dashboard_authentication_spec.rb
+++ b/spec/requests/dashboard_authentication_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Every dashboard endpoint must refuse an unauthenticated request. This exists
+# because LocalesController shipped without authentication: the filter was
+# declared on ErrorsController rather than on ApplicationController, so a
+# controller added later inherited no protection and nothing failed to say so.
+#
+# The generic example below walks the engine's real route set, so a controller
+# added tomorrow is covered without anyone remembering to add it here.
+RSpec.describe "Dashboard authentication", type: :request do
+  let!(:application) { create(:application) }
+
+  before do
+    RailsErrorDashboard.configuration.authenticate_with = nil
+    RailsErrorDashboard.configuration.dashboard_username = "admin"
+    RailsErrorDashboard.configuration.dashboard_password = "secret123"
+  end
+
+  after do
+    RailsErrorDashboard.configuration.authenticate_with = nil
+  end
+
+  def auth_header(user = "admin", pass = "secret123")
+    { "HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Basic.encode_credentials(user, pass) }
+  end
+
+  describe "without credentials" do
+    it "refuses the locale picker (it is a state-changing POST)" do
+      post "/error_dashboard/locale", params: { locale: "de" }
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(session[:red_locale]).to be_nil
+    end
+
+    it "refuses the error list" do
+      get "/error_dashboard/errors"
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "refuses the overview" do
+      get "/error_dashboard/overview"
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    # The point of the whole spec: no GET route may answer 2xx unauthenticated.
+    it "refuses every GET route the engine exposes" do
+      leaked = RailsErrorDashboard::Engine.routes.routes.filter_map do |route|
+        next unless route.verb.include?("GET")
+
+        path = route.path.spec.to_s.sub("(.:format)", "")
+        next if path.include?(":")  # needs an id; the controller-level filter covers these
+
+        get "/error_dashboard#{path}"
+        "#{path} -> #{response.status}" if response.status < 400
+      rescue StandardError
+        nil
+      end
+
+      expect(leaked).to be_empty, "unauthenticated GETs that did not refuse:\n  #{leaked.join("\n  ")}"
+    end
+  end
+
+  describe "with valid credentials" do
+    # CSRF is left ON for the unauthenticated examples above — authentication
+    # must refuse before forgery protection is even reached, and disabling it
+    # there would hide which of the two did the refusing. Here we are past
+    # that question and testing the happy path, so the token check is disabled
+    # the way the other picker specs do it: request specs cannot mint a valid
+    # token, and the real picker uses button_to, which supplies one.
+    before { ActionController::Base.allow_forgery_protection = false }
+    after  { ActionController::Base.allow_forgery_protection = true }
+
+    it "allows the locale picker through" do
+      post "/error_dashboard/locale", params: { locale: "de" }, headers: auth_header
+
+      expect(response).to have_http_status(:redirect)
+      expect(session[:red_locale]).to eq("de")
+    end
+
+    it "allows the error list through" do
+      get "/error_dashboard/errors", headers: auth_header
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "with wrong credentials" do
+    it "refuses the locale picker" do
+      post "/error_dashboard/locale", params: { locale: "de" }, headers: auth_header("admin", "wrong")
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(session[:red_locale]).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## The bug

`LocalesController` — the language picker added in the i18n work, **not yet released** — required no authentication. `authenticate_dashboard_user!` was declared on `ErrorsController`, so it protected that controller and nothing else. A controller added later inherited from `ApplicationController` and got no filter.

Measured:

```
GET  /error_dashboard/overview   (no credentials)  -> 401
POST /error_dashboard/locale     (no credentials)  -> 500   <-- no auth
POST /error_dashboard/locale     (bad credentials) -> 500   <-- no auth
```

The 500 rather than 401 is the tell: the request reached controller code, `create` rescued its own error, redirected to `overview_path`, and *that* route's filter produced the failure. No `WWW-Authenticate` header was ever sent.

## Impact — limited, and worth stating precisely

The action reads only `params[:locale]`, writes `session[:red_locale]`, and touches no error data. It **discloses nothing and cannot modify stored records**; the session it writes belongs to the caller, and the value is validated against the shipped locale list regardless.

So this is not a data-exposure bug. It is an endpoint that answered unauthenticated requests — and it would have been the template every future controller copied.

**Never released.** `LocalesController` exists only on `main` since #155 and has never shipped in a published gem.

## The fix moves the filter up rather than adding a second one

`before_action :authenticate_dashboard_user!` now lives on `ApplicationController`. That inverts the default: a controller is protected unless it explicitly opts out with `skip_before_action` — a visible, reviewable act instead of an omission nobody notices. Adding the filter to `LocalesController` alone would have fixed this instance and left the next one to happen.

Already correct, now pinned: basic auth uses `ActiveSupport::SecurityUtils.secure_compare` with `&` (not `&&`), so both comparisons always run and the check is timing-safe.

## Tests

`spec/requests/dashboard_authentication_spec.rb`. The load-bearing example walks the engine's **real route set** and asserts no GET answers 2xx without credentials, so a controller added tomorrow is covered without anyone remembering to extend the file.

CSRF is deliberately left **enabled** for the unauthenticated examples: authentication must refuse before forgery protection is reached, and disabling it there would hide which check did the refusing.

Verified red-then-green — removing the new `before_action` fails exactly the two locale examples with 500 where 401 is expected.

## Also here

`SECURITY.md` told reporters to use GitHub private vulnerability reporting, which was **disabled** — a dead end. PVR is now enabled, and the policy documents both it and `security@anjan.dev` so one channel failing no longer leaves a researcher with nowhere to go.

## Test plan

- Suite **4201 → 4208 (+7), 0 failures**
- RuboCop clean on 535 files
- `bin/pre-release-test all` — 5 apps, **1442/1442** (the auth path runs on every dashboard request)
- `bin/i18n-check` exit 0

---

Found while auditing after a researcher reported PVR was disabled. **This is not their report** — theirs has not arrived, and may be something else entirely.

Refs #148