### PR TITLE
docs(changelog): add the 0.9.0 i18n release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,61 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### 0.9.0 highlights — the dashboard is now translated
+
+> Detail for the `feat(i18n)` entry above.
+
+RED's dashboard, its emails and its notification payloads render in **eleven
+languages**. Set the default with `config.dashboard_locale`, and users can
+override it for themselves from a picker in the navbar:
+
+```ruby
+RailsErrorDashboard.configure do |config|
+  config.dashboard_locale = "de"  # en, de, es, fr, pt-BR, ja, ru, uk, pl, it, zh-CN
+end
+```
+
+`en` (source) · `de` Deutsch · `es` Español · `fr` Français · `pt-BR` Português
+(Brasil) · `ja` 日本語 · `ru` Русский · `uk` Українська · `pl` Polski ·
+`it` Italiano · `zh-CN` 简体中文
+
+**Your application's `I18n` is untouched.** RED translates through its own
+private backend, so it never reads, writes or mutates `I18n.load_path`,
+`I18n.locale`, `I18n.available_locales`, `I18n.default_locale`, `I18n.backend`
+or `I18n.exception_handler`. RED's locale is independent of your app's — a host
+running in French can render the dashboard in German, and vice versa. This also
+means hosts cannot override RED's strings with their own locale files, which is
+a deliberate trade-off for a self-hosted ops tool.
+
+Nothing in the translation path can raise. A missing or wrong translation
+**falls back to English**, never to a broken page — which matters on the one
+page that has to work when everything else is broken.
+
+**Upgrading changes nothing unless you opt in.** The default locale is `en`, and
+English rendering is unchanged.
+
+#### ⚠️ Every non-English locale is machine-translated and unreviewed
+
+**None of the ten translations has been reviewed by a native speaker.** RED's
+maintainer reads only English. This is stated plainly rather than as "beta",
+which would imply a review process that has not happened.
+
+What is and is not verified:
+
+- Key structure, interpolation variables and CLDR plural categories **are**
+  verified mechanically in every locale, on every CI run.
+- Wording, register and idiom are **not** verified by anyone.
+
+**Corrections are very welcome, and a one-key PR is a perfectly good PR.** If
+you read any of these languages, [every locale has an open issue][review-issues]
+tracking its review, or you can [report a bad translation][report] without
+touching any code. See the [translations guide][guide] for how the system works,
+what is deliberately left in English, and how to add a language.
+
+[review-issues]: https://github.com/AnjanJ/rails_error_dashboard/issues?q=is%3Aissue+is%3Aopen+label%3Atranslation%3Aneeds-review
+[report]: https://github.com/AnjanJ/rails_error_dashboard/issues/new?template=translation_report.yml
+[guide]: https://github.com/AnjanJ/rails_error_dashboard/blob/main/docs/guides/TRANSLATIONS.md
+
 ## [0.8.4](https://github.com/AnjanJ/rails_error_dashboard/compare/rails_error_dashboard/v0.8.3...rails_error_dashboard/v0.8.4) (2026-08-13)
 
 


### PR DESCRIPTION
## What

Adds the hand-written 0.9.0 release notes from `tasks/CHANGELOG_INSERT_v0.9.0.md` into `CHANGELOG.md`. Documentation only — 55 added lines, no shipped code changes.

## Why

Release-please generates one line per conventional commit. Without this, 0.9.0 — the largest feature RED has shipped — goes out described as *"translate the dashboard, mailers and notifications — eleven locales"* and nothing else. The prose covers the locale list, the config snippet, the host-`I18n`-untouched guarantee, the English-fallback behaviour, and the machine-translated/unreviewed disclosure.

## Placement is load-bearing, and was verified rather than assumed

Three constraints, all checked against the actual tooling:

1. **Release-please prepends.** It writes its section directly below the SemVer line and leaves everything beneath untouched — so prose below that point survives regeneration.
2. **It cannot go on the release branch.** Release-please force-pushes and regenerates that branch on every push to main; it did exactly that after #168 merged, rewriting `5986f0a`. An edit committed there would be discarded.
3. **It cannot use a hand-written `## [0.9.0]` heading on main.** The generated section would land *above* it and the file would carry two 0.9.0 headings, with the bullets orphaned from the prose explaining them.

So the block is a `###` nested **under** the generated `## [0.9.0]`, a sibling of its Features and Bug Fixes subsections, with a one-line pointer back to the `feat(i18n)` entry it expands.

I simulated the prepend against this file and read the output. Resulting heading order:

```
## [0.9.0](…) (2026-08-22)
### ✨ Features
### 🐛 Bug Fixes
### 0.9.0 highlights — the dashboard is now translated
#### ⚠️ Every non-English locale is machine-translated and unreviewed
## [0.8.4](…) (2026-08-13)
```

## Notes

- Typed `docs:` deliberately — the release config hides that type, so this does not itself trigger a competing release PR.
- Verified all three links return 200, `.github/ISSUE_TEMPLATE/translation_report.yml` exists, and both the `translation` and `translation:needs-review` labels exist.
- Once this merges, release-please will regenerate #166 on top of it. #166 stays held for your call.

Refs #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)