### PR TITLE
docs(gemspec): state the eleven-locale i18n support in summary and description

### DIFF
--- a/rails_error_dashboard.gemspec
+++ b/rails_error_dashboard.gemspec
@@ -7,7 +7,8 @@ Gem::Specification.new do |spec|
   spec.email       = [ "anjan.jagirdar@gmail.com" ]
   spec.homepage    = "https://AnjanJ.github.io/rails_error_dashboard"
   spec.summary     = "Self-hosted error tracking for Rails — local variables, system health, " \
-                     "separate or shared database. A free, open-source Sentry alternative."
+                     "separate or shared database, dashboard in 11 languages. " \
+                     "A free, open-source Sentry alternative."
   spec.description = "Own your errors. Own your stack. A fully open-source, self-hosted error tracking " \
                      "Rails engine — a free Sentry alternative that runs entirely inside your own " \
                      "process, with no external services and zero recurring cost. " \
@@ -23,6 +24,14 @@ Gem::Specification.new do |spec|
                      "workflow management, advanced analytics, platform detection (iOS/Android/Web/API), " \
                      "and two-way issue sync with GitHub, GitLab, Codeberg, and Linear. Also: LLM " \
                      "observability, AI-powered debugging help, and OpenTelemetry span export. " \
+                     "The dashboard, mailers and notification payloads are translated into 11 " \
+                     "languages: English, German, Spanish, French, Brazilian Portuguese, Italian, " \
+                     "Polish, Russian, Ukrainian, Japanese, and Simplified Chinese — 1,515 source " \
+                     "strings, set via config.dashboard_locale with a per-user picker. RED " \
+                     "translates through its own private I18n backend and never mutates your app's " \
+                     "I18n; a missing translation falls back to English. Backtraces, exception " \
+                     "names and webhook payload keys stay English by design. The ten non-English " \
+                     "locales are machine-translated and not yet reviewed by native speakers. " \
                      "5-minute setup, works out-of-the-box. Rails 7.0-8.1, Ruby 3.2-4.0. " \
                      "BETA: API may change before v1.0.0. " \
                      "Live demo: https://rails-error-dashboard.anjan.dev (gandalf/youshallnotpass)"


### PR DESCRIPTION
## What

Adds i18n to the gemspec `summary` and `description`. Metadata only — no code changes.

## Why

0.9.0 shipped the dashboard, mailers and notification payloads translated into eleven languages, but neither field mentioned i18n at all. The RubyGems page is where most people decide whether to try the gem, and it wasn't carrying the release's headline feature.

## What it says

Summary gains `dashboard in 11 languages` (166 chars — still one line on the listing).

Description gains a paragraph before the setup/version tail covering: the eleven languages by name, the 1,515-key source count, `config.dashboard_locale` and the per-user picker, the private-I18n-backend guarantee, the English fallback, that diagnostics stay English by design, and that the ten non-English locales are machine-translated and not yet reviewed by native speakers.

Facts only, no adjectives. Every number is checked against the shipped locale files (11 files; 1,515 leaf keys in `en.yml`) rather than estimated.

Including the unreviewed status is deliberate: someone choosing this gem for its German UI should learn that from the listing, not after installing.

## Verification

- `Gem::Specification.load` parses clean; summary and description render as intended
- RuboCop clean

## Note

This does **not** change the already-published 0.9.0 listing — gem metadata is frozen at publish time, so RubyGems will pick it up at the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)