### PR TITLE
fix(specs): stop the load_path pin silently passing zero arguments

### DIFF
--- a/spec/lib/rails_error_dashboard/private_backend_spec.rb
+++ b/spec/lib/rails_error_dashboard/private_backend_spec.rb
@@ -55,7 +55,17 @@ RSpec.describe RailsErrorDashboard::PrivateBackend do
 
       stock.translate(:en, "red.pinned")
 
-      expect(stock.send(:translations).keys).to include(*I18n.backend.send(:translations).keys),
+      # The host backend is lazy: nothing here has forced it to read its own
+      # load_path, and on some orderings nothing earlier in the suite has
+      # either. Left uninitialized its translations hash is empty, the splat
+      # below passes zero arguments, and `include()` raises ArgumentError
+      # instead of asserting anything — the pin silently stops pinning.
+      I18n.backend.send(:init_translations) unless I18n.backend.initialized?
+      host_locales = I18n.backend.send(:translations).keys
+      expect(host_locales).not_to be_empty,
+        "the host backend must hold translations for this pin to mean anything"
+
+      expect(stock.send(:translations).keys).to include(*host_locales),
         "upstream init_translations no longer reads I18n.load_path — " \
         "PrivateBackend#init_translations may no longer be needed"
     end


### PR DESCRIPTION
## What

`spec/lib/rails_error_dashboard/private_backend_spec.rb:45` asserted with:

```ruby
expect(stock.send(:translations).keys).to include(*I18n.backend.send(:translations).keys)
```

The host backend is lazy. If nothing has forced it to read its own `load_path`, that hash is empty, the splat passes **zero arguments**, and RSpec raises:

```
ArgumentError: include() is not supported, please supply an argument
```

Spec-only change. No shipped code touched.

## Why it matters

On orderings where no earlier example initialized the host backend, this pin didn't weakly pass — it **errored**. On every other ordering it asserted normally. Seed 42409 hits it; most seeds don't.

This is a canary spec: it exists to tell you when upstream `I18n::Backend::Simple` stops absorbing `I18n.load_path`, so `PrivateBackend#init_translations` can be dropped. A pin that raises instead of asserting isn't pinning anything.

## Pre-existing, not from the PR that surfaced it

Found on #171 (a gemspec-description-only change). `rspec --seed 42409` on **clean `main`** fails identically — same single example, nothing of mine present. The 0.9.0 release CI passed only because its seed happened to order an initializing example first.

## Diagnosis

Probed rather than guessed. A `before` hook printing the state at the failing example reported:

```
PROBE host_backend_keys=[] load_path_size=334
```

A populated `load_path` that had never been read — which names the cause exactly.

## The fix

Initialize the host backend if needed, then assert the key list is non-empty *before* using it as the expectation. A future emptiness now fails loudly on its own message instead of erroring out of the splat.

## The pin still pins

Mutation-verified. Simulating "upstream stopped absorbing load_path" by dropping the absorbed locales makes it fail with its intended message — `upstream init_translations no longer reads I18n.load_path` — so the guard is intact, not defanged.

## Test plan

- `rspec --seed 42409` → **4208 examples, 0 failures** (was 1 failure)
- RuboCop clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)