### PR TITLE
fix(security): refuse default credentials outside development and test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,57 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### 0.9.1 highlights — default credentials are now refused outside development and test
+
+> Detail for the `fix(security)` entry above. Security advisory:
+> [GHSA-qhgm-3pxf-mvc6](https://github.com/AnjanJ/rails_error_dashboard/security/advisories/GHSA-qhgm-3pxf-mvc6),
+> reported by [@rajnisht7](https://github.com/rajnisht7).
+
+RED has always refused to boot on the built-in `gandalf` / `youshallnotpass`
+credentials — but the check asked `Rails.env.production?`, which tests one
+literal string. An internet-facing app deployed under any other environment
+name (`staging`, `uat`, `demo`, `preprod`, `qa`) booted successfully on
+credentials this project publishes in its own README. The only remaining
+protection was a dismissible banner, visible only to someone who was already
+inside.
+
+The guard is now an **allowlist**: only `development` and `test` may run on the
+built-in credentials. Every other environment name — including ones that do not
+exist yet — is refused by default.
+
+#### ⚠️ This can stop an app booting when you upgrade
+
+**If you run RED in a non-production environment on the default credentials,
+that app will now raise `ConfigurationError` on boot instead of starting.** That
+is the intended outcome — it was reachable with published credentials — but it
+is a behaviour change, so it is called out here rather than buried.
+
+The error names the environment it refused, and there are three ways to fix it:
+
+```ruby
+# 1. Set the environment variables (recommended)
+ENV["ERROR_DASHBOARD_USER"]     = "..."
+ENV["ERROR_DASHBOARD_PASSWORD"] = "..."
+
+# 2. Or set them in the initializer
+RailsErrorDashboard.configure do |config|
+  config.dashboard_username = "..."
+  config.dashboard_password = ENV.fetch("ERROR_DASHBOARD_PASSWORD")
+end
+
+# 3. Or hand authentication to your own app
+RailsErrorDashboard.configure do |config|
+  config.authenticate_with = -> { current_user&.admin? }
+end
+```
+
+Setting either environment variable is enough to satisfy the check — RED treats
+an explicitly-set variable as a deliberate choice.
+
+**Unaffected:** apps already setting credentials or `authenticate_with`; apps
+running only in `development` or `test`; and Docker asset precompilation, which
+is still skipped via `SECRET_KEY_BASE_DUMMY`.
+
 ## [0.9.0](https://github.com/AnjanJ/rails_error_dashboard/compare/rails_error_dashboard/v0.8.4...rails_error_dashboard/v0.9.0) (2026-08-23)
 
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1049,7 +1049,7 @@ This is a **self-hosted only feature** — impossible for SaaS error trackers. W
 - **Custom authentication** via `config.authenticate_with` lambda — use Devise, Warden, session-based, or any auth system
 - **Configurable credentials** via environment variables
 - **Fail-closed security** — lambda errors are rescued, logged, and result in 403 Forbidden
-- **Default credentials protection** — App refuses to boot in production with default (`gandalf/youshallnotpass`) or blank credentials. Dashboard shows a reminder banner in all environments until credentials are changed
+- **Default credentials protection** — App refuses to boot with default (`gandalf/youshallnotpass`) or blank credentials in **any environment except development and test** — including `staging`, `uat`, `demo` and any other name you deploy under. Dashboard shows a reminder banner in all environments until credentials are changed
 
 ### Data Privacy
 - **Self-hosted** - all data stays on your infrastructure

--- a/lib/rails_error_dashboard/configuration.rb
+++ b/lib/rails_error_dashboard/configuration.rb
@@ -478,12 +478,22 @@ module RailsErrorDashboard
       errors = []
       warnings = []
 
-      # Block boot with default or blank credentials in production
+      # Block boot with default or blank credentials anywhere that is not local
+      # development or test.
+      #
+      # Deliberately an ALLOWLIST of safe environments rather than a check for
+      # `production`. Gating on Rails.env.production? tests one literal string,
+      # so an internet-facing `staging`, `uat`, `demo` or `preprod` box booted
+      # happily on credentials this project publishes in its own README
+      # (GHSA-qhgm-3pxf-mvc6). Every future environment name a team invents is
+      # now refused by default and has to be added here on purpose.
+      #
       # Skip during asset precompilation (SECRET_KEY_BASE_DUMMY=1) — ENV vars aren't available at build time
       if default_credentials? &&
-         defined?(Rails) && Rails.respond_to?(:env) && Rails.env.production? &&
+         defined?(Rails) && Rails.respond_to?(:env) &&
+         !Rails.env.development? && !Rails.env.test? &&
          ENV["SECRET_KEY_BASE_DUMMY"].blank?
-        errors << "Default or blank credentials cannot be used in production. Set ERROR_DASHBOARD_USER and ERROR_DASHBOARD_PASSWORD environment variables, or use authenticate_with for custom auth."
+        errors << "Default or blank credentials cannot be used in #{Rails.env}. Only development and test may run on the built-in credentials. Set ERROR_DASHBOARD_USER and ERROR_DASHBOARD_PASSWORD environment variables, or use authenticate_with for custom auth."
       end
 
       # Validate sampling_rate (must be between 0.0 and 1.0)

--- a/spec/lib/rails_error_dashboard/configuration_validation_spec.rb
+++ b/spec/lib/rails_error_dashboard/configuration_validation_spec.rb
@@ -841,7 +841,7 @@ RSpec.describe RailsErrorDashboard::Configuration, "#validate!" do
     end
   end
 
-  describe "default credentials in production" do
+  describe "default credentials outside development and test" do
     it "raises ConfigurationError in production with default credentials" do
       allow(Rails).to receive(:env).and_return(ActiveSupport::EnvironmentInquirer.new("production"))
 
@@ -885,6 +885,59 @@ RSpec.describe RailsErrorDashboard::Configuration, "#validate!" do
 
     it "does not raise in production during asset precompilation (SECRET_KEY_BASE_DUMMY)" do
       allow(Rails).to receive(:env).and_return(ActiveSupport::EnvironmentInquirer.new("production"))
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("SECRET_KEY_BASE_DUMMY").and_return("1")
+
+      expect { config.validate! }.not_to raise_error
+    end
+
+    # GHSA-qhgm-3pxf-mvc6. The guard used to read Rails.env.production?, which
+    # tests one literal string, so an internet-facing box under any other
+    # environment name booted on the credentials this project publishes in its
+    # own README. These are the environment names that used to be exempt.
+    [ "staging", "uat", "demo", "preprod", "qa", "review" ].each do |env_name|
+      it "raises ConfigurationError in #{env_name} with default credentials" do
+        allow(Rails).to receive(:env).and_return(ActiveSupport::EnvironmentInquirer.new(env_name))
+
+        expect { config.validate! }.to raise_error(
+          RailsErrorDashboard::ConfigurationError,
+          /Default or blank credentials cannot be used in #{env_name}/
+        )
+      end
+    end
+
+    it "names the offending environment rather than saying production" do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::EnvironmentInquirer.new("staging"))
+
+      expect { config.validate! }.to raise_error(
+        RailsErrorDashboard::ConfigurationError,
+        /cannot be used in staging/
+      )
+    end
+
+    it "does not raise in test with default credentials" do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::EnvironmentInquirer.new("test"))
+
+      expect { config.validate! }.not_to raise_error
+    end
+
+    it "does not raise in staging once credentials are set" do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::EnvironmentInquirer.new("staging"))
+      config.dashboard_username = "admin"
+      config.dashboard_password = "secure_pass"
+
+      expect { config.validate! }.not_to raise_error
+    end
+
+    it "does not raise in staging when authenticate_with is set" do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::EnvironmentInquirer.new("staging"))
+      config.authenticate_with = -> { true }
+
+      expect { config.validate! }.not_to raise_error
+    end
+
+    it "does not raise in staging during asset precompilation (SECRET_KEY_BASE_DUMMY)" do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::EnvironmentInquirer.new("staging"))
       allow(ENV).to receive(:[]).and_call_original
       allow(ENV).to receive(:[]).with("SECRET_KEY_BASE_DUMMY").and_return("1")
 


### PR DESCRIPTION
Fixes [GHSA-qhgm-3pxf-mvc6](https://github.com/AnjanJ/rails_error_dashboard/security/advisories/GHSA-qhgm-3pxf-mvc6), reported by @rajnisht7.

## The problem

The boot-time guard against the built-in `gandalf` / `youshallnotpass` credentials asked `Rails.env.production?` — **one literal string**. An internet-facing app deployed under any other environment name booted happily on credentials this project publishes in its own README, its demo page, and its gemspec description.

The only remaining protection was a dismissible banner, visible only to someone who had already got in.

Reproduced before fixing:

```
production   BLOCKED
staging      BOOTS  <- default creds accepted
demo         BOOTS  <- default creds accepted
uat          BOOTS  <- default creds accepted
preprod      BOOTS  <- default creds accepted
```

## The fix is an allowlist, not a longer denylist

`!Rails.env.development? && !Rails.env.test?` inverts the default: only the two genuinely-local environments may run on built-in credentials, and **every environment name a team invents in future is refused without anyone remembering to add it**.

A denylist of "production, staging, uat, …" would have fixed the names we thought of today and left the next one exposed — which is exactly how this bug happened.

The message now names the environment it refused (`cannot be used in staging`) instead of saying "in production", which was actively confusing in the case that mattered.

## Deliberately unchanged

- `default_credentials?` still returns false when either ENV var is set. An explicitly-set variable is a deliberate choice even at a weak value; this guard is about *untouched defaults*, not password strength.
- The `SECRET_KEY_BASE_DUMMY` skip stays, so Docker `assets:precompile` still builds without runtime ENV vars.
- The reminder banner is untouched.

## ⚠️ Breaking for some upgrades, on purpose

An app running RED in staging on the default credentials will now raise `ConfigurationError` on boot rather than start. That is the correct outcome — it was reachable with published credentials — but it is a behaviour change, so `CHANGELOG.md` carries a "this can stop an app booting" section with the three ways out (ENV vars, initializer, or `authenticate_with`).

## Test plan

- **Verified RED-then-green:** reverting just the condition back to `Rails.env.production?` fails exactly **7** of the new examples; restoring it passes **17/17**.
- 6 parameterised examples pin `staging`/`uat`/`demo`/`preprod`/`qa`/`review`, one asserts the message names the environment, and four pin the ways *out* (creds set, `authenticate_with`, test env, `SECRET_KEY_BASE_DUMMY`).
- Suite **4208 → 4219** (+11), 0 failures. RuboCop clean on 535 files.
- Chaos: **5 apps, 1442/1442, 0 failed** (read from the FINAL RESULTS block, not the exit code).
- `docs/FEATURES.md` no longer claims the guard is production-only. `CHANGELOG.md:541` is left alone — it is a historical record of what 0.x shipped.

Targeting **0.9.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)