### PR TITLE
docs(security): replace both bouncing @anjan.dev addresses

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -10,8 +10,8 @@ contact_links:
     url: https://github.com/AnjanJ/rails_error_dashboard#readme
     about: Read the documentation for setup, configuration, and usage guides
   - name: 🔒 Security Vulnerability (Private)
-    url: mailto:security@anjan.dev
-    about: Report critical security vulnerabilities privately via email
+    url: https://github.com/AnjanJ/rails_error_dashboard/security/advisories/new
+    about: Report a vulnerability privately — visible only to you and the maintainer
   - name: 💼 Commercial Support
-    url: mailto:conduct@anjan.dev
+    url: mailto:anjan.jagirdar+red@gmail.com
     about: Contact us for commercial support, consulting, or partnerships

--- a/.github/ISSUE_TEMPLATE/security.yml
+++ b/.github/ISSUE_TEMPLATE/security.yml
@@ -10,7 +10,7 @@ body:
 
         If you've discovered a **critical security vulnerability**, please **DO NOT** open a public issue.
 
-        Instead, please report it privately to: **security@anjan.dev**
+        Instead, please use [private vulnerability reporting](https://github.com/AnjanJ/rails_error_dashboard/security/advisories/new) — it is visible only to you and the maintainer.
 
         For **non-critical security concerns** or **security enhancement suggestions**, you may use this template.
 
@@ -127,7 +127,7 @@ body:
           required: true
         - label: I have not exploited this vulnerability in production systems
           required: true
-        - label: I understand that critical vulnerabilities should be reported privately to security@anjan.dev
+        - label: I understand that critical vulnerabilities should be reported through GitHub private vulnerability reporting, not this public form
           required: true
 
   - type: markdown

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -80,7 +80,7 @@ This Code of Conduct also applies when representing the project in public spaces
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project team at:
 
-**Email:** conduct@anjan.dev
+**Email:** anjan.jagirdar+red@gmail.com
 
 All complaints will be:
 - Reviewed and investigated promptly and fairly
@@ -190,7 +190,7 @@ When reporting, please include:
 If you have questions about this Code of Conduct:
 
 - Open a [GitHub Discussion](https://github.com/AnjanJ/rails_error_dashboard/discussions)
-- Email: conduct@anjan.dev
+- Email: anjan.jagirdar+red@gmail.com
 - Reach out to project maintainers
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Following these guidelines helps communicate that you respect the time of the de
 
 ## Code of Conduct
 
-This project and everyone participating in it is governed by our [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to conduct@anjan.dev.
+This project and everyone participating in it is governed by our [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to anjan.jagirdar+red@gmail.com.
 
 ## How Can I Contribute?
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,9 +17,8 @@ If you're using an older version and discover a security issue, please upgrade t
 
 ### How to Report
 
-**Either of these works. Both are private — pick whichever is easier for you.**
-
-**1. GitHub private vulnerability reporting (preferred)**
+**Use GitHub private vulnerability reporting.** It is the only reporting channel,
+and it is private.
 
 1. Go to [Report a vulnerability](https://github.com/AnjanJ/rails_error_dashboard/security/advisories/new)
 2. Fill out the form with as much detail as possible
@@ -27,15 +26,16 @@ If you're using an older version and discover a security issue, please upgrade t
 The report is visible only to you and the maintainer. It also gives us a place
 to work through the fix together and to publish an advisory crediting you.
 
-**2. Email — [security@anjan.dev](mailto:security@anjan.dev)**
+A plain description is fine — do not let formatting slow you down.
 
-If you would rather not use GitHub, or the link above is not working for you
-for any reason, email us directly. A plain description is fine; do not let
-formatting slow you down.
+There is deliberately no email address here. This project previously listed one
+that silently bounced, which is worse than listing nothing: a report you believe
+was delivered was not. A single channel that demonstrably works is better than a
+second one nobody can verify.
 
-**If one channel does not work, use the other rather than filing a public
-issue.** If neither works, that is a bug in this policy — say so in an email
-and we will fix it.
+**If the form does not work for you**, open a normal issue saying only that you
+have a security report and need a way to send it — no details — and you will be
+given one. Please do not put vulnerability details in a public issue.
 
 ### What to Include in Your Report
 
@@ -91,7 +91,7 @@ When using Rails Error Dashboard:
 If you have questions about this security policy or need to discuss something that doesn't fit the reporting process above, you can reach out by:
 
 - Creating a [GitHub Discussion](https://github.com/AnjanJ/rails_error_dashboard/discussions) for general security questions
-- Emailing the maintainer directly (for sensitive matters that aren't vulnerabilities)
+- Using the [private reporting form](https://github.com/AnjanJ/rails_error_dashboard/security/advisories/new) for anything that should not be public
 
 ## Thank You
 


### PR DESCRIPTION
## The problem

**Neither address on the `anjan.dev` domain delivers.** Both `security@` and `conduct@` bounce with *"the remote server is misconfigured"* — confirmed by sending to each.

The DNS is fine (MX and SPF point at Namecheap forwarding), but no forwarding rules exist, so mail is refused.

**A published address that silently bounces is worse than no address.** Someone reporting a vulnerability or a conduct violation believes they have disclosed privately, and nobody ever sees it. That is the exact failure these policies exist to prevent, and it was sitting inside both of them.

## Two contacts, two different fixes

They need different things, so they get different answers.

### Security → the GitHub form, no email at all

Removed `security@anjan.dev` from `SECURITY.md`, both spots in `security.yml`, and the `config.yml` contact link.

GitHub private vulnerability reporting is now the only channel: enabled, returns 200, and demonstrably working — [GHSA-qhgm-3pxf-mvc6](https://github.com/AnjanJ/rails_error_dashboard/security/advisories/GHSA-qhgm-3pxf-mvc6) arrived through it. **One verified channel beats two where one cannot be.**

SECURITY.md now says out loud that the absence of an email is deliberate and why, so it reads as a decision rather than an oversight — plus a no-details escape hatch (open an ordinary issue asking for a channel) for anyone the form fails.

### Code of Conduct → a real mailbox, because the security answer doesn't fit

A harassment report **cannot** be told to open a public issue, and the security advisory form is the wrong venue — it files a security advisory for a conduct complaint, and advisory collaborators can read it.

So `conduct@anjan.dev` → `anjan.jagirdar+red@gmail.com` in `CODE_OF_CONDUCT.md` (×2), `CONTRIBUTING.md`, and the config.yml commercial-support link.

Plus-addressed rather than the bare personal address: it delivers to the same Gmail mailbox but is filterable, and keeps the address in project docs distinct from the one in the gemspec, so scraped-and-spammed project mail can be triaged separately. (`+` is a literal in a `mailto:` local part, so the link works unencoded.)

## Verification

- Both YAML issue templates re-parse; all contact links resolve
- Advisory form URL returns 200
- No `@anjan.dev` addresses remain anywhere in the repo

Docs and issue templates only. No gem code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)