### PR TITLE
docs(roadmap,skills): refresh the roadmap to v0.9.1 and backfill the safety skill

### DIFF
--- a/.claude/skills/host-app-safety/SKILL.md
+++ b/.claude/skills/host-app-safety/SKILL.md
@@ -7,7 +7,7 @@ user-invocable: false
 
 This gem runs INSIDE the host Rails app's process. Every line of code we write can break the host app. These rules are non-negotiable.
 
-## The 10 Safety Rules
+## The 11 Safety Rules
 
 1. **Never raise in the error capture path** — rescue at every layer. If our error tracker raises while capturing an error, we've made the situation worse.
 2. **Never block the request path** — all heavy work (notifications, analytics) must be async/background. The request thread must return ASAP.
@@ -16,32 +16,68 @@ This gem runs INSIDE the host Rails app's process. Every line of code we write c
 5. **Always re-raise original exceptions** — Sentry #1173: swallowed Sidekiq exceptions prevented retries. After capture, always `raise` the original.
 6. **Feature-detect before calling** — `defined?(Puma)`, `respond_to?(:stats)`. Never assume a server/library exists.
 7. **Make everything disableable** — every request-path feature needs a config flag. Users must be able to turn off anything that causes problems.
-8. **Never use ObjectSpace.each_object** — freezes all threads, grows heap. Use `GC.stat` instead for memory info.
+8. **Never use ObjectSpace.each_object** — freezes all threads and grows the heap, and the cost compounds across later GC cycles. Use `GC.stat` for memory info. `ObjectSpace.count_objects` **is** allowed: it returns O(1) type counts without walking the heap, and `DiagnosticDumpGenerator` uses it deliberately.
 9. **Never use Signal.trap** — breaks Puma/Sidekiq signal handling (USR1/USR2 reserved). Use rake tasks for diagnostics.
 10. **Never store Binding objects** — prevents GC of entire call stack. Extract local variables immediately into plain data.
+11. **Never call `Thread#backtrace` across `Thread.list`** — collecting backtraces for every thread holds the GVL while it walks each stack, stalling the whole process. Capture thread name/status/alive only. `DiagnosticDumpGenerator` notes this explicitly.
 
 ## Real-World Incidents
 
 ### Sentry #1173 — Swallowed Sidekiq Retries
 Middleware captured exception but forgot to re-raise. Sidekiq treated failed jobs as successful. Retries never happened. Production data loss.
+[sentry-ruby#1173](https://github.com/getsentry/sentry-ruby/issues/1173)
 
 ### Puma #823 — Thread-Local Leak Across Keepalive
 Thread.current values leaked between requests on the same keepalive connection. Puma only cleaned thread-locals before new work assignment, not between requests.
+[puma#823](https://github.com/puma/puma/issues/823)
 
 ### Coverband — TracePoint :line Was 2.5x Slower
 Abandoned TracePoint :line in favor of Coverage API (1.08x vs 2.5x overhead). Never use :line in production by default.
+[coverage_rails_benchmark](https://github.com/danmayer/coverage_rails_benchmark)
 
 ### Ruby #18264 — TracePoint Memory Leak
 `rb_tp_t` struct allocated with RUBY_TYPED_NEVER_FREE in Ruby 2.6-3.0. Repeatedly creating TracePoints caused unbounded RSS growth. Gate on Ruby >= 3.2.
+[bugs.ruby-lang.org#18264](https://bugs.ruby-lang.org/issues/18264)
 
 ### Rails AS::Notifications — Subscribers CAN Crash Requests
 `iterate_guarding_exceptions` collects subscriber exceptions and RE-RAISES them. A buggy subscriber on `sql.active_record` crashes the SQL query's caller. Breadcrumb subscriber MUST have its own rescue.
+[rails fanout.rb](https://github.com/rails/rails/blob/main/activesupport/lib/active_support/notifications/fanout.rb)
 
 ### Rack Middleware Constant Mutation
 Shared mutable headers hash in a constant grew unbounded across requests. Never use mutable constants for per-request data.
+[bernardoamc.com/rails-middleware-leak](https://bernardoamc.com/rails-middleware-leak/)
 
 ### Signal.trap — Last Writer Wins
 Puma uses USR1 (phased restart), USR2 (full restart). Sidekiq Enterprise uses USR2. Signal.trap completely replaces previous handler — no chaining.
+[sidekiq#3803](https://github.com/sidekiq/sidekiq/issues/3803)
+
+### Sentry #1246 — Transport Swallowed Network Errors
+`Sentry::Transport.send_data` caught all network errors silently; `transport_failure_callback` never fired on 4xx/5xx. Transport failures were completely invisible. Rescuing is not enough — always log what failed and why. A silent rescue in our notification dispatch would fail the same way.
+[sentry-ruby#1246](https://github.com/getsentry/sentry-ruby/issues/1246)
+
+### SolidQueue #271 — Connection Pool Exhaustion
+Default pool config didn't account for polling and heartbeat connections. Each worker thread needs its own connection, plus 2 extra: `pool >= (threads * processes) + dispatcher_threads + 2`. If we run background jobs, document the pool requirement — our separate-database option is the mitigation.
+[solid_queue#271](https://github.com/rails/solid_queue/issues/271)
+
+### Mailboxer #480 — Index Name Too Long
+An engine migration generated `index_mailboxer_notifications_on_notified_object_type_and_notified_object_id`, exceeding PostgreSQL's 63-character limit. The migration fails on the host app's database, during their deploy. Always name compound indexes explicitly in our migrations; never rely on auto-generated names.
+[mailboxer#480](https://github.com/mailboxer/mailboxer/issues/480)
+
+### Puma #2767 — Signal Handler Coexistence Is Unsolved
+Puma attempted "non-overriding" signal handlers that coexist with handlers registered before it, and had to override its own previous traps while preserving third-party ones. The PR demonstrates the problem is fundamentally hard. This is the evidence behind Rule 9 — don't try to be a good citizen with signals, just don't use them.
+[puma#2767](https://github.com/puma/puma/pull/2767)
+
+## Lessons from Competitors
+
+Every major error-tracking SDK has had an incident where it damaged the host app. The pattern repeats: an edge case where the SDK's own error handling fails, and that failure propagates into the application.
+
+**Sentry Ruby** — background worker thread pool for async transport, so network failures never touch the request thread. Transport defines `HTTP_ERRORS` (Timeout::Error, SocketError, Errno constants), all caught and logged, never propagated. `Sentry::Rack::CaptureExceptions` captures, reports, then re-raises. Stated design principle: "Any exception that happens after `Sentry.capture_*` is called shouldn't crash the user's app."
+
+**Honeybadger** — single-threaded worker processing one Notice at a time, isolated from request threads. Queue capped at 100; when full, new notices are **dropped**. Adaptive throttling multiplies delay by 1.05x on throttle responses. Middleware is `rescue Exception => raised; notify; raise` — bare `raise` preserves the original. Synchronous fallback at exit skips the worker queue when the process is already crashing.
+
+**Bugsnag** — `skip_bugsnag` property on exceptions prevents duplicate notifications when re-raised through multiple handlers. Middleware is not allowed to change critical `handledState` properties. Explicit protection against exception-unwrapping infinite loops via the `original_exception` pattern. Built-in middleware can be force-disabled if it misbehaves.
+
+**Key takeaway:** the only defense is defense in depth — rescue at every layer, always re-raise the original, and prefer data loss over application damage. Honeybadger dropping notices at a full queue is the model: our storm protection (circuit breaker + adaptive sampling, v0.8.2) is the same trade made deliberately.
 
 ## Performance Budgets
 
@@ -62,19 +98,51 @@ When reviewing changes to the capture path (`middleware/`, `error_subscriber.rb`
 - [ ] No `raise` statements (except re-raising the original)
 - [ ] No blocking I/O (HTTP calls, file reads, external services)
 - [ ] Thread.current cleaned in `ensure`
-- [ ] No `ObjectSpace`, `Signal.trap`, or `Binding` storage
+- [ ] No `ObjectSpace.each_object`, `Signal.trap`, `Thread#backtrace`, or `Binding` storage
+      (`ObjectSpace.count_objects` is O(1) and allowed — see Rule 8)
 - [ ] Feature-gated with config check
 - [ ] Performance measured and within budget
 
-## Existing Known Issues
+## Memory-Bounding Patterns (all three original issues now fixed)
 
-1. `dashboard_stats.rb:343` — `average_resolution_time` loads all records into memory (should use SQL SUM)
-2. `pattern_detector.rb:64` — iterates errors in Ruby instead of SQL GROUP BY
-3. `cascade_detector.rb:64` — nested query loops without LIMIT bounds
+The three unbounded-memory issues this file used to list as open are fixed. They are kept here as
+worked examples, because the same mistake is easy to reintroduce. All three live under
+`lib/rails_error_dashboard/`, not `app/` — the paths in older notes are stale.
 
-## Roadmap Risk Ratings
+1. **`queries/dashboard_stats.rb`** — `average_resolution_time` loaded every resolved record to
+   average them in Ruby. Now aggregates in SQL via `scope.pick(Arel.sql(avg_seconds_sql))`, with a
+   per-adapter expression. **Pattern: aggregate in the database, not in Ruby.**
+2. **`services/pattern_detector.rb`** — iterated ActiveRecord objects to build an hourly
+   distribution. Now a pure function taking an array of plucked timestamps, so the caller controls
+   what is loaded. **Pattern: push data loading out to the caller; keep analysis pure.**
+3. **`services/cascade_detector.rb`** — nested query loops with no LIMIT. Now `pluck`s
+   `(error_log_id, occurred_at)` and runs an O(N + pairs) two-pointer sweep over the time-sorted
+   rows. Its own comment records why: ~16 bytes/row instead of ~5KB/row, because the host app
+   schedules this job and the lookback window may be large. **Pattern: pluck the two columns you
+   need, never load the row.**
 
-- **CRITICAL**: AS::Notifications subscribers (breadcrumbs), TracePoint :line (dual mode), Signal.trap (diagnostic dump)
-- **HIGH**: TracePoint :raise, swallowed exception detection, retention DELETE
-- **MEDIUM**: System health snapshot, auto-reopen race condition, background job health
-- **LOW**: Flexible auth, BRIN index migration, GitHub issue creation
+When adding any query that could touch an unbounded number of rows, pick one of these three shapes.
+
+## Risk Ratings — Shipped Surfaces
+
+These were written as pre-implementation risk ratings; all of them have since shipped. They now
+say where the danger already lives, so treat them as a map of what to re-check when touching
+these areas.
+
+- **CRITICAL**: AS::Notifications subscribers (breadcrumbs) — must self-rescue or crash the
+  caller's SQL query. TracePoint `:line` (detailed mode) — 2.5x overhead, opt-in only.
+  Signal.trap was rated critical and consequently **never built**: the diagnostic dump uses
+  `at_exit` and an explicit call instead (see Rule 9).
+- **HIGH**: TracePoint `:raise`, swallowed-exception detection, retention DELETE (batch it —
+  `in_batches(of: 1000)`, never a single unbounded DELETE).
+- **MEDIUM**: system health snapshot, auto-reopen race condition, background job health.
+- **LOW**: flexible auth, BRIN index migration, issue-tracker creation.
+
+Since these ratings were written, three further request-path surfaces shipped and belong on the
+map: **storm protection** (circuit breaker + adaptive sampling, v0.8.2) and **Rack::Attack event
+tracking** are both HIGH — they run on live traffic, and Rack::Attack has already needed four
+correctness fixes. **Outbound OTel export** (v0.8.0) is MEDIUM: `Integrations::Tracer.emit?` gates every span on
+the master `enable_otel_export` flag, the OTel API actually being loaded, and the span kind
+appearing in `config.otel_spans` — which defaults to all four kinds, so it is opt-out per
+kind once export is on. When any gate fails it yields a `NOOP_SPAN` and preserves the block's
+return value, which is the pattern to copy for any future façade.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,14 +1,21 @@
 # Rails Error Dashboard — Roadmap
 
-> Last updated: May 31, 2026 | Current version: v0.7.0
-> Deep introspection analysis: [DEEP_INTROSPECTION_ANALYSIS.md](DEEP_INTROSPECTION_ANALYSIS.md)
-> Faultline comparison: [FAULTLINE_COMPARISON.md](FAULTLINE_COMPARISON.md)
-> Time-series strategy: [TIMESERIES_ANALYSIS.md](TIMESERIES_ANALYSIS.md)
-> **Host app safety: [HOST_APP_SAFETY.md](HOST_APP_SAFETY.md)** — MUST READ before implementing any feature
+> Last updated: August 25, 2026 | Current version: v0.9.1 | Next: v0.10.0 (PR #177, held)
+>
+> **Working analysis docs are local-only, by design.** Earlier revisions of this file linked to
+> `DEEP_INTROSPECTION_ANALYSIS.md`, `FAULTLINE_COMPARISON.md`, `TIMESERIES_ANALYSIS.md` and
+> `HOST_APP_SAFETY.md`. All four exist on the maintainer's machine but are listed in `.gitignore`
+> (lines 55-59) and have never been committed, so the links were dead for every reader of the
+> public repo. The links are removed here rather than repaired.
+>
+> **The safety knowledge itself is committed and current** — `HOST_APP_SAFETY.md` was distilled
+> into `.claude/skills/host-app-safety/SKILL.md`, which carries its rules (7 expanded to 10),
+> performance budgets, incident post-mortems and code-review checklist. `CLAUDE.md` rule 1 is the
+> one-line form. Nothing load-bearing depends on the uncommitted originals.
 
 ## The Big Picture
 
-The gem sits in a **sweet spot**: more capable than Solid Errors (475 stars, minimal by design) and Faultline (64 stars, brand new), but infinitely simpler to run than self-hosted Sentry (12+ Docker services). The positioning is clear:
+The gem sits in a **sweet spot**: more capable than Solid Errors (488 stars, minimal by design) and Faultline (87 stars, young), but infinitely simpler to run than self-hosted Sentry (12+ Docker services). The positioning is clear:
 
 > **"It's just a gem."** No Docker Compose, no separate services, no DevOps team. `bundle install`, migrate, mount, done.
 
@@ -16,23 +23,28 @@ The gem sits in a **sweet spot**: more capable than Solid Errors (475 stars, min
 
 | Metric | rails_error_dashboard | solid_errors | faultline | findbug | exception_notification |
 |--------|-----------------------|-------------|-----------|---------|----------------------|
-| Total Downloads | 11,000+ | 276,761 | N/A (git-only) | 1,447 | 22,144,698 |
-| GitHub Stars | 70+ | 481 | 72 | 25 | 2,185 |
-| Last Commit | 2026-03-27 (active) | 2025-11-24 (stale) | 2026-03-06 (active) | 2026-02-25 (active) | 2021-12-28 (dead) |
+| Total Downloads | 37,381 | 377,820 | N/A (git-only) | 2,542 | 23,958,401 |
+| GitHub Stars | 90 | 488 | 87 | 25 | 2,173 |
+| Last Commit | 2026-08-24 (active) | 2025-11-24 (stale) | 2026-05-14 (slowing) | 2026-02-25 (active) | 2025-03-22 (dormant) |
 | Dashboard UI | Yes (Bootstrap 5) | Yes (minimal) | Yes (Tailwind) | Yes | No |
 | Notifications | Slack, Email, Discord, PagerDuty, Webhooks | Email | Telegram, Slack, Email, Webhooks | Slack, Email, Discord, Webhooks | Email, Slack, many more |
+| Issue Trackers | GitHub, GitLab, Codeberg, Linear | No | No | No | No |
+| i18n | 11 locales (v0.9.0) | No | No | No | No |
+| OpenTelemetry | In + out (v0.7.0/v0.8.0) | No | No | No | No |
+| LLM Observability | Yes (v0.7.0) | No | No | No | No |
 | Rails Versions | 7.0 - 8.1 | 7.1+ | 8.0+ | 7.0+ | 7.1+ |
 | Dependencies | 2 required + optional | 0 extra | 0 extra | 7 (incl. Redis) | 2 |
 | Local Variables | Yes (TracePoint) | No | Yes (TracePoint) | No | No |
 | Auth | HTTP Basic + Custom Lambda | N/A | Devise/Warden/Lambda | ? | N/A |
 | Error Model | Single record + count | Single record | Group + Occurrences | Single record | N/A |
-| GitHub Issues | Yes (GitHub, GitLab, Codeberg) | No | Yes | No | No |
+| GitHub Issues | Yes (GitHub, GitLab, Codeberg, Linear) | No | Yes | No | No |
 | Auto-Reopen | Yes | No | Yes | No | N/A |
 | Copy for LLM | Yes (v0.5.3+) | No | No | No | No |
-| Telegram | Not yet | No | Yes | No | No |
-| Performance Monitoring | Planned (v0.6) | No | No | Yes (Redis-based) | No |
+| Telegram | Not yet (7a, open) | No | Yes | No | No |
+| Performance Monitoring | Deferred, see (Z) | No | No | Yes (Redis-based) | No |
 
-> **Detailed comparison:** See [FAULTLINE_COMPARISON.md](FAULTLINE_COMPARISON.md) for full feature-by-feature analysis.
+> Download and star counts verified against RubyGems and the GitHub API on 2026-08-25. `faultline` is
+> git-only, so its RubyGems row stays N/A; its star count is the `dlt/faultline` repo.
 
 ### vs SaaS (Sentry, Honeybadger, Rollbar, Bugsnag, Airbrake)
 
@@ -157,7 +169,7 @@ These features are impossible or impractical for SaaS error trackers. They repre
 
 ## Deep Introspection — Ruby VM-Level Capabilities
 
-> **Full analysis**: See [DEEP_INTROSPECTION_ANALYSIS.md](DEEP_INTROSPECTION_ANALYSIS.md) for complete research including competitive analysis, implementation architecture, benchmarks, and sources.
+> The research behind this section — competitive analysis, implementation architecture, benchmarks and sources — lived in an uncommitted working doc. The conclusions that survived it are stated inline below, including the performance budget table at the end of this section.
 
 These features use Ruby's VM-level APIs and TracePoint to capture context that **no other error tracker** provides. The research validates that these are production-safe — Sentry ships TracePoint(:raise) globally, and all system health APIs are read-only with <1ms overhead.
 
@@ -280,6 +292,7 @@ Environment:
 - **Implementation:** `ActiveSupport::Notifications.subscribe("throttle.rack_attack")`, guard with `defined?(Rack::Attack)`, store as breadcrumbs or dedicated counter
 - **Effort:** Half day
 - **Impact:** Operational + (useful if Rack Attack is installed)
+- **Reworked three times since.** v0.8.3 (#143) made events persist independently of error capture — they were previously lost unless an error happened to fire. v0.8.4 (#150) surfaced a missing `rack-attack` gem instead of failing silently. **v0.10.0 (PR #177, held)** fixes the remaining three defects found via issue [#170](https://github.com/AnjanJ/rails_error_dashboard/issues/170): `track` events never set a discriminator (so "Unique IPs" always read 0 next to a real count), counts were silently lost on LRU eviction, and there was no flush on shutdown. It also adds AI-agent classification from the User-Agent header
 
 ### S. ActionCable Connection Monitoring -- DONE (v0.5.0)
 - **What:** Track WebSocket connection counts, channel actions, transmissions, subscription confirmations/rejections. Surface ActionCable health alongside errors
@@ -331,13 +344,15 @@ Environment:
 - **Why it's deliberately deferred:** Shipping shallow APM invites comparison to mature tools and dilutes our core strength. Our real edge is *depth of debugging context from inside the process* (locals, cause chains, breadcrumbs, swallowed-exception detection, health panels) — that advantage compounds the further we push it, and APM doesn't draw on it. If we ever build this, it must be excellent and Redis-free, with a strict host-app-safety budget (opt-in, sampled, async, ring-buffer pattern, never blocks the request), not a checkbox
 - **Effort / Impact:** Not estimated — out of scope until core excellence is achieved
 
-### AA. Dashboard Internationalization — EXTRACTION AND LOCALES SHIPPED, RELEASE PENDING
-- **Status:** Phases 1-6 of `tasks/i18n-sprint-plan.md` are complete on `feat/i18n-layout-nav`; only Phase 7 (verification and release) remains. The ~1,600-string extraction that this item previously deferred is **done**: roughly 1,500 keys across views, inline JS, mailers and notification payloads now render through `red_t`. Full spec lives in `tasks/todo.md` and `tasks/i18n-sprint-plan.md`
-- **What shipped:** A private I18n backend isolated from the host app, request-scoped locale state, the `red_t` helper family, plural/relative-time/date-format helpers, a dynamic `<html lang>`, the full string extraction, a JS translation payload, localized mailers and notification payloads, a session-persisted language picker, and `bin/i18n-check` to verify locale files mechanically. **Eleven locales ship** — `en` (source) plus `de`, `es`, `fr`, `pt-BR`, `ja`, `ru`, `uk`, `pl`, `it` and `zh-CN`, all machine-translated and explicitly unreviewed, since the maintainer reads only English
-- **What remains:** The Phase 7 verification and release pass — host-safety audit, visual and layout QA across every locale, and the release itself. No translation work is outstanding
-- **Why it moved:** The original deferral reasoned that i18n is reach rather than depth, and that translation quality is a tax in languages the maintainer cannot read. The second concern turned out to be the tractable one: `bin/i18n-check` enforces every property a script can verify (key parity, interpolation variables, CLDR plural categories), and the English fallback means a wrong translation degrades to English rather than to a broken page. What cannot be automated — wording, register, idiom — is labelled unreviewed rather than pretended away
-- **Demand signal:** Still no user request and zero i18n issues filed. The work proceeded because the foundation made it incremental, not because demand appeared
-- **Effort:** Foundation 2-3 days (done) · extraction + tooling ~14 days (done) · locales ~4 days (done) · verification and release (remaining)
+### AA. Dashboard Internationalization — DONE (v0.9.0)
+- **Status:** Shipped 2026-08-24 in v0.9.0. All 7 phases of `tasks/i18n-sprint-plan.md` are complete and merged (#155)
+- **What shipped:** A private I18n backend isolated from the host app, request-scoped locale state, the `red_t` helper family, plural/relative-time/date-format helpers, a dynamic `<html lang>`, the full ~1,500-key extraction across views, inline JS, mailers and notification payloads, a JS translation payload, a session-persisted language picker, and `bin/i18n-check` to verify locale files mechanically. **Eleven locales ship** — `en` (source) plus `de`, `es`, `fr`, `pt-BR`, `ja`, `ru`, `uk`, `pl`, `it` and `zh-CN`
+- **Translation quality is explicitly unreviewed.** Every non-English locale is machine-translated, because the maintainer reads only English. `bin/i18n-check` enforces what a script can verify — key parity, interpolation variables, CLDR plural categories — and the English fallback means a wrong translation degrades to English rather than a broken page. Wording, register and idiom are labelled unreviewed rather than pretended away
+- **Open follow-up:** issues [#156–#165](https://github.com/AnjanJ/rails_error_dashboard/issues/156) — one per locale, tagged `good first issue` / `translation:needs-review`, inviting native speakers to correct wording. These stay open by design; they are the contribution path, not a backlog
+- **That path has already paid for itself.** The first reviewer to take one up (@gmarziou, French, #158) reported not a wording problem but two real bugs: chart date axes rendering in English in every locale, and inverted axis titles on the horizontal bar chart — plus a latent third (issue #178, fixed in PR #179). Worth stating plainly, because `bin/i18n-check` could not have caught any of it: it verifies key structure, interpolation variables and plural categories, not what reaches a `<canvas>`. **A locale can pass every mechanical check and still render English on every chart.** When auditing i18n coverage, grep for `strftime` and `to_json` in views, not only for missing `red_t` calls — data serialized to JS is the blind spot
+- **Two follow-up fixes landed after the release:** pagination rendering in the dashboard's own locale (v0.8.4, #152) and authenticating every dashboard controller rather than only `ErrorsController` (v0.9.0, #167)
+- **Demand signal:** still no user request and zero i18n issues filed before the work started. It proceeded because the foundation made it incremental, not because demand appeared
+- **Effort (actual):** foundation 2-3 days · extraction + tooling ~14 days · locales ~4 days · verification and release ~2 days
 - **Impact:** Reach ++ (adoption in non-English-speaking teams)
 
 ### Y. Lazy Backtrace via Thread.each_caller_location (Ruby 3.2+)
@@ -437,7 +452,7 @@ All overhead numbers validated against Sentry's production benchmarks and Ruby d
 - **What:** Add conditional migration that uses BRIN index on `occurred_at` for PostgreSQL (72KB vs 676MB for B-tree, near-identical time-range query performance). Add functional index on `date_trunc('day', occurred_at)` to speed up Groupdate queries by up to 70x
 - **Why:** Error logs are insert-heavy, naturally time-ordered data — the exact use case BRIN indexes are designed for. Our DashboardStats makes 7+ COUNT queries per page load; AnalyticsStats does `group_by_day` over 30 days. These indexes make both instant. Zero runtime dependency, just smarter indexing
 - **Community impact:** Dashboard stays responsive at 100K+ rows without any user configuration
-- **Learned from:** Time-series database research. See [TIMESERIES_ANALYSIS.md](TIMESERIES_ANALYSIS.md)
+- **Learned from:** Time-series database research (working doc, not committed)
 - **Effort:** Half day
 - **Implemented:** Migration adds BRIN index on `occurred_at` + functional index for Groupdate (PostgreSQL only, graceful SQLite fallback)
 
@@ -464,11 +479,12 @@ All overhead numbers validated against Sentry's production benchmarks and Ruby d
 - **Effort:** Half day
 - **Impact:** Adoption ++ (closes gap with faultline, reaches new developer communities)
 
-### 8. GitHub/GitLab Issue Creation
+### 8. GitHub/GitLab Issue Creation — DONE (v0.5.8, extended v0.8.1)
 - **What:** One-click "Create GitHub Issue" from the error detail page. Pre-fill with error details, backtrace, context. Link back to the error in the dashboard. Track issue status
 - **Why:** Faultline (a direct competitor) already has this and it's likely contributing to their faster star growth (64 vs 28). This bridges the gap between "I see the error" and "I'm working on it"
 - **Community impact:** Most-requested integration across all error tracking tools. Natural next step after "see error -> assign error"
 - **Effort:** 1-2 days
+- **Implemented:** Four providers — GitHub, GitLab and Codeberg in v0.5.8, Linear added in v0.8.1 (#133). Manual creation, auto-create, lifecycle sync and inbound webhooks
 
 ### 9. Environment/Stage Awareness
 - **What:** Track which environment errors come from (development/staging/production). Filter by environment. Show environment badge on errors. Separate notification rules per environment
@@ -557,14 +573,16 @@ All overhead numbers validated against Sentry's production benchmarks and Ruby d
 
 ## Tier 5 — Community & Growth (not code, but critical)
 
-### 21. Submit to awesome-ruby
+### 21. Submit to awesome-ruby — NOW ELIGIBLE
 - The [awesome-ruby](https://github.com/markets/awesome-ruby) list is the most-referenced curated list for Ruby gems
 - Not being on it means most developers will never discover the gem
 - **Single highest-leverage action for visibility**
+- **Status changed.** The list requires 30K+ downloads. Earlier revisions of this roadmap recorded us at ~11K and therefore ineligible. **We are now at 37,381** — the bar is cleared and this is unblocked. Not yet submitted
 
-### 22. Submit to Ruby Toolbox
+### 22. Submit to Ruby Toolbox — SUBMITTED, AWAITING MERGE
 - Ruby Toolbox categorizes gems and shows comparative stats
 - Being listed under "Exception Notification" alongside exception_notification, solid_errors, and airbrake would immediately surface the gem
+- **Status:** [rubytoolbox/catalog#1033](https://github.com/rubytoolbox/catalog/pull/1033) opened and still open as of 2026-08-25 — not merged. Nothing further to do on our side
 
 ### 23. Write a Launch Blog Post
 - "Why I built a self-hosted error dashboard for Rails" on dev.to or Medium
@@ -572,148 +590,123 @@ All overhead numbers validated against Sentry's production benchmarks and Ruby d
 - Show screenshots, link to live demo
 - This is how gems get their first 100 stars
 
-### 24. Fix Default Credentials Warning
+### 24. Fix Default Credentials Warning — DONE (hardened in v0.9.1)
 - Raise an error on startup if `dashboard_username` is still "gandalf" and `dashboard_password` is still "youshallnotpass" in production
 - Users will ship with demo credentials — this is a security issue that will come up in every code review
+- **Implemented, then found insufficient.** The original guard asked `Rails.env.production?`, which tests one literal string — an internet-facing app deployed as `staging`, `uat`, `demo`, `preprod` or `qa` booted fine on credentials this project publishes in its own README. Reported by [@rajnisht7](https://github.com/rajnisht7) as [GHSA-qhgm-3pxf-mvc6](https://github.com/AnjanJ/rails_error_dashboard/security/advisories/GHSA-qhgm-3pxf-mvc6) (high). v0.9.1 replaces the check with an **allowlist**: only `development` and `test` may run on built-in credentials; every other environment name — including ones that do not exist yet — is refused. This is a breaking boot-time change and is called out in the changelog
+- **Open loop:** the CVE ID for the advisory had not been assigned as of 2026-08-25. The reporter is owed an email once it lands
 
 ---
 
 ## Priority Matrix & Release Plan
 
-### Implementation Phases
+### Where we actually are
 
-Each phase builds on the previous. Phase 1 features are quick wins (hours each). Phase 3-4 are the game-changers that differentiate us from every competitor.
+Nine months, 654 commits, 78 published versions, currently **v0.9.1**. The version-by-version
+table that used to live here had gone stale in a way that made it actively misleading — it still
+targeted i18n at "v1.1+" months after it shipped in v0.9.0, and listed features at v0.5/v0.6 that
+had been done since spring. It has been replaced by the shipped history below plus a short,
+honest forward list.
 
-| Priority | Feature | Effort | Impact | Phase |
-|----------|---------|--------|--------|-------|
-| **NOW** | Submit to awesome-ruby & Ruby Toolbox | 1 hour | Visibility +++ | Community |
-| **NOW** | Fix default credentials warning | 1 hour | Trust +++ | Community |
-| **NOW** | Write launch blog post | 4 hours | Awareness +++ | Community |
-| | | | | |
-| ~~**v0.2**~~ | ~~Exception cause chain (L)~~ | ~~2-3 hours~~ | ~~Debugging ++~~ | ~~Phase 1: Quick Wins~~ **DONE** |
-| ~~**v0.2**~~ | ~~Enriched error context (J) — method, headers, hostname, timing~~ | ~~4-6 hours~~ | ~~Parity +++~~ | ~~Phase 1~~ **DONE** |
-| ~~**v0.2**~~ | ~~Structured backtrace (use `backtrace_locations`)~~ | ~~2-3 hours~~ | ~~Quality ++~~ | ~~Phase 1~~ **DONE** |
-| ~~**v0.2**~~ | ~~Environment info — Ruby, Rails, gem versions at boot~~ | ~~2-3 hours~~ | ~~Context ++~~ | ~~Phase 1~~ **DONE** |
-| ~~**v0.2**~~ | ~~Auto user context via CurrentAttributes (D)~~ | ~~3-4 hours~~ | ~~Zero-config ++~~ | ~~Phase 1~~ **DONE** |
-| ~~**v0.2**~~ | ~~Sensitive data filtering (use `filter_parameters`)~~ | ~~4-6 hours~~ | ~~Safety +++~~ | ~~Phase 1~~ **DONE** |
-| ~~**v0.2**~~ | ~~Notification rules & throttling (with per-error cooldown)~~ | ~~1-2 days~~ | ~~Production-readiness +++~~ | ~~Phase 1~~ **DONE** |
-| ~~**v0.2**~~ | ~~Auto-reopen resolved errors on recurrence~~ | ~~Half day~~ | ~~Correctness +++~~ | ~~Phase 1~~ **DONE** |
-| ~~**v0.2**~~ | ~~Custom fingerprint lambda~~ | ~~Half day~~ | ~~Extensibility ++~~ | ~~Phase 1~~ **DONE** |
-| **v0.2** | Data retention enforcement (background job, batch delete) | 1 day | Production-readiness ++ | Phase 1 |
-| ~~**v0.2**~~ | ~~BRIN index + functional index for PostgreSQL~~ | ~~Half day~~ | ~~Performance +++~~ | ~~Phase 1~~ **DONE** |
-| ~~**v0.2**~~ | ~~Reduce dependencies (make optional)~~ | ~~1 day~~ | ~~Adoption barrier --~~ | ~~Phase 1~~ **DONE** |
-| ~~**v0.2**~~ | ~~Backtrace line numbers in error detail view~~ | ~~PR #69~~ | ~~UX ++~~ | ~~Community contribution~~ **DONE** |
-| ~~**v0.2**~~ | ~~Loading states & skeleton screens (Stimulus)~~ | ~~PR #71~~ | ~~UX +++~~ | ~~Community contribution~~ **DONE** |
-| | | | | |
-| **ICEBOX** | JSON API | 2-3 days | Extensibility +++ | Deferred |
-| ~~**ICEBOX**~~ | ~~Flexible auth (Devise/Warden/custom lambda)~~ | ~~1 day~~ | ~~Adoption +++~~ | ~~Deferred~~ **DONE (v0.3.0)** |
-| | | | | |
-| **v0.3** | Rollup/summary tables (optional `rollup` gem) | 1-2 days | Performance +++ | Phase 2: System Health |
-| ~~**v0.3**~~ | ~~System health snapshot as JSONB column (C)~~ | ~~2-3 days~~ | ~~Differentiation ++~~ | ~~Phase 2~~ **DONE** |
-| ~~**v0.3**~~ | ~~System health UI (display in error detail)~~ | ~~1-2 days~~ | ~~UX ++~~ | ~~Phase 2~~ **DONE** |
-| | | | | |
-| ~~**v0.4**~~ | ~~Breadcrumb collector — ring buffer, thread-local (A)~~ | ~~1-2 days~~ | ~~Foundation +++~~ | ~~Phase 3: Breadcrumbs~~ **DONE** |
-| ~~**v0.4**~~ | ~~AS::Notifications subscriber — SQL, controller, cache, jobs~~ | ~~2-3 days~~ | ~~Differentiation +++~~ | ~~Phase 3~~ **DONE** |
-| ~~**v0.4**~~ | ~~Logger breadcrumbs~~ | ~~Half day~~ | ~~Context ++~~ | ~~Phase 3~~ **DONE** |
-| ~~**v0.4**~~ | ~~Manual breadcrumb API (`RailsErrorDashboard.add_breadcrumb`)~~ | ~~Half day~~ | ~~Extensibility ++~~ | ~~Phase 3~~ **DONE** |
-| ~~**v0.4**~~ | ~~Breadcrumb persistence (text column on error_logs)~~ | ~~1 day~~ | ~~Storage ++~~ | ~~Phase 3~~ **DONE** |
-| ~~**v0.4**~~ | ~~Breadcrumb timeline UI~~ | ~~2-3 days~~ | ~~UX +++~~ | ~~Phase 3~~ **DONE** |
-| ~~**v0.4**~~ | ~~N+1 detection from SQL breadcrumbs (B)~~ | ~~1 day~~ | ~~Differentiation +++~~ | ~~Phase 3~~ **DONE** |
-| | | | | |
-| ~~**v0.5**~~ | ~~Local variable capture — TracePoint `:raise` (K)~~ | ~~2-3 days~~ | ~~Game-changer +++~~ | ~~Phase 4: TracePoint~~ **DONE (v0.4.0)** |
-| ~~**v0.5**~~ | ~~Variable serializer (circular detection, depth limits, sensitive names)~~ | ~~1 day~~ | ~~Safety +++~~ | ~~Phase 4~~ **DONE (v0.4.0)** |
-| ~~**v0.5**~~ | ~~Instance variable capture on self (M)~~ | ~~1 day~~ | ~~Debugging ++~~ | ~~Phase 4~~ **DONE (v0.4.0)** |
-| **v0.5** | Debugger Inspector UI (side-by-side source + variables) | 1-2 days | UX +++ | Phase 4 |
-| ~~**v0.5**~~ | ~~Swallowed exception detection — TracePoint :rescue (N)~~ | ~~2-3 days~~ | ~~Novel +++~~ | ~~Phase 4~~ **DONE (v0.4.0)** |
-| ~~**v0.5**~~ | ~~Swallowed exception dashboard UI~~ | ~~2-3 days~~ | ~~UX ++~~ | ~~Phase 4~~ **DONE (v0.4.0)** |
-| | | | | |
-| ~~**v0.5**~~ | ~~Deploy/release tracking~~ | ~~2 days~~ | ~~Workflow +++~~ | ~~Phase 5: Workflow~~ **DONE (v0.5.10)** |
-| ~~**v0.5**~~ | ~~Error replay — copy as curl/RSpec (E)~~ | ~~1-2 days~~ | ~~Novel +++~~ | ~~Phase 5~~ **DONE (v0.4.0)** |
-| ~~**v0.6**~~ | ~~GitHub/GitLab/Codeberg issue creation (Tier 1: manual, Tier 2: auto-create + lifecycle sync, Tier 3: webhooks)~~ | ~~3-5 days~~ | ~~Workflow +++~~ | ~~Phase 5~~ **DONE (v0.5.8)** |
-| **v0.5** | Telegram notifications (7a) | Half day | Adoption ++ | Phase 5 |
-| **v0.5** | Optional PostgreSQL partitioning generator | 1-2 days | Scale ++ | Phase 5 |
-| ~~**v0.5**~~ | ~~User impact scoring~~ | ~~1 day~~ | ~~Prioritization ++~~ | ~~Phase 5~~ **DONE (v0.5.11)** |
-| ~~**v0.6**~~ | ~~Process crash capture — at_exit hook (O)~~ | ~~Half day~~ | ~~Reliability ++~~ | ~~Phase 5~~ **DONE (v0.4.0)** |
-| ~~**v0.6**~~ | ~~On-demand diagnostic dump (P)~~ | ~~Half day~~ | ~~Operational ++~~ | ~~Phase 5~~ **DONE (v0.4.0)** |
-| | | | | |
-| ~~**v0.7**~~ | ~~Deprecation warning tracker (F)~~ | ~~1 day~~ | ~~Unique ++~~ | ~~Phase 6: Health Panels~~ **DONE (v0.3.0)** |
-| **v0.6** | Missing translation tracking (I18n silent errors) | Half day | Unique ++ | Phase 6 |
-| **v0.6** | Validation failure pattern tracking (ActiveModel) | 1 day | Insight ++ | Phase 6 |
-| ~~**v0.7**~~ | ~~Background job health panel (G)~~ | ~~1-2 days~~ | ~~Operational ++~~ | ~~Phase 6~~ **DONE (v0.3.1)** |
-| ~~**v0.7**~~ | ~~Database health panel (H)~~ | ~~1-2 days~~ | ~~Operational ++~~ | ~~Phase 6~~ **DONE (v0.3.1)** |
-| ~~**v0.7**~~ | ~~Cache health monitoring (I)~~ | ~~1 day~~ | ~~Operational +~~ | ~~Phase 6~~ **DONE (v0.3.0)** |
-| **v0.6** | Environment awareness | 1 day | Team workflow ++ | Phase 6 |
-| ~~**v0.7**~~ | ~~Rack Attack event tracking (R)~~ | ~~Half day~~ | ~~Operational +~~ | ~~Phase 6~~ **DONE (v0.4.0)** |
-| **v0.6** | Performance monitoring — request timing, slow queries (Z) | 3-4 days | Differentiation +++ | Phase 6 |
-| ~~**v0.6**~~ | ~~ActionCable connection monitoring (S)~~ | ~~Half day~~ | ~~Operational +~~ | ~~Phase 6~~ **DONE (v0.5.0)** |
-| **v0.6** | Zeitwerk loading error capture (T) | Half day | Reliability + | Phase 6 |
-| **v0.6** | ActiveStorage service health (U) | Half day | Operational + | Phase 6 |
-| ~~**v0.7**~~ | ~~YJIT runtime stats (W)~~ | ~~Half day~~ | ~~Operational +~~ | ~~Phase 6~~ **DONE (v0.4.0)** |
-| ~~**v0.7**~~ | ~~RubyVM cache health (X)~~ | ~~Half day~~ | ~~Debugging +~~ | ~~Phase 6~~ **DONE (v0.4.0)** |
-| | | | | |
-| **v0.8** | RBAC | 2-3 days | Enterprise ++ | Phase 7: Enterprise |
-| **v0.8** | Audit logging | 1 day | Enterprise ++ | Phase 7 |
-| ~~**v0.8**~~ | ~~Scheduled digests~~ | ~~1-2 days~~ | ~~Engagement ++~~ | ~~Phase 7~~ **DONE (v0.5.11)** |
-| **v0.8** | Adaptive sampling (auto-reduce on spike) | 2-3 days | Resilience ++ | Phase 7 |
-| **v0.8** | Optional TimescaleDB generator (hypertables, compression, continuous aggregates) | 2-3 days | Scale +++ | Phase 7 |
-| | | | | |
-| **v1.0** | Full Context Error Report (unified view) | 3-5 days | Flagship +++ | Phase 8: 1.0 |
-| **v1.0** | Error-environment correlation | 3-5 days | Analytics ++ | Phase 8 |
-| **v1.0** | AI error summaries | 2-3 days | Buzz +++ | Phase 8 |
-| **v1.0** | Comparison mode | 1-2 days | Analytics ++ | Phase 8 |
-| ~~**v1.0**~~ | ~~Production code path coverage — Coverage oneshot_lines (V)~~ | ~~2-3 days~~ | ~~Debugging ++~~ | ~~Phase 8~~ **DONE (v0.5.11)** |
-| **v1.0** | Lazy backtrace — Thread.each_caller_location (Y) | Half day | Performance + | Phase 8 |
-| | | | | |
-| ~~**v0.7**~~ | ~~LLM call breadcrumbs — capture model, provider, tokens, duration, tool calls as breadcrumbs when errors occur during LLM requests. Support RubyLLM (via OTel spans if `opentelemetry-instrumentation-ruby_llm` present), langchain.rb, OpenAI SDK, Anthropic SDK. Content capture opt-in (PII risk). No monkey-patching — subscribe to existing instrumentation. Fields: `gen_ai.provider.name`, `gen_ai.request.model`, `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, `gen_ai.request.temperature`, tool call name/arguments. Ref: [thoughtbot/opentelemetry-instrumentation-ruby_llm](https://github.com/thoughtbot/opentelemetry-instrumentation-ruby_llm)~~ | ~~2-3 days~~ | ~~Novel +++~~ | ~~Phase 9: AI Observability~~ **DONE (v0.7.0)** |
-| ~~**v0.7**~~ | ~~LLM tool call tracking — capture tool executions (name, arguments, result) nested within LLM calls. When an error occurs during a tool call, the breadcrumb shows which tool failed and why~~ | ~~1 day~~ | ~~Debugging +++~~ | ~~Phase 9~~ **DONE (v0.7.0)** |
-| ~~**v0.7**~~ | ~~LLM health dashboard page — `/errors/llm_health_summary` showing per-model breakdown: call count, avg tokens, avg latency, error rate, cost estimate. Sorted by error correlation (models with most errors first)~~ | ~~2-3 days~~ | ~~Unique +++~~ | ~~Phase 9~~ **DONE (commit 9c1be38 on fix/llm-observability-filter-and-css)** |
-| ~~**v0.8**~~ | ~~OpenTelemetry span export (outbound) — emit error capture operations as OTel spans for Datadog/Honeycomb/Jaeger. Error logged → span with error type, severity, capture latency. Integrates with existing OTel collector if present. Note: v0.7.0 ships the inbound direction (OTel spans → RED breadcrumbs via LlmSpanProcessor); this item is the symmetric outbound direction~~ | ~~2-3 days~~ | ~~Ecosystem +++~~ | ~~Phase 9~~ **DONE (feat/otel-export branch)** — `Integrations::Tracer` façade wraps LogError, BreadcrumbCollector, SystemHealthSnapshot, ErrorNotificationDispatcher. Per-span opt-in via `config.otel_spans`. |
-| ~~**v0.7**~~ | ~~Copy for LLM — include LLM call context when available (model, tokens, tool calls, prompt if opt-in). The LLM debugging an error can see the LLM call that preceded it~~ | ~~1 day~~ | ~~Meta +++~~ | ~~Phase 9~~ **DONE (v0.7.0)** — `MarkdownErrorFormatter#llm_calls_section` |
-| ~~**v0.8**~~ | ~~Self-instrumentation — measure gem overhead as OTel spans (error capture latency, breadcrumb collection, system health snapshot). Users can verify <5ms budget in their own observability dashboards. Depends on outbound OTel span export above~~ | ~~1 day~~ | ~~Trust ++~~ | ~~Phase 9~~ **DONE (feat/otel-export branch)** — shipped together with outbound export. The four spans (capture/breadcrumbs/health/notifications) emit timing for every gem operation in the capture path. |
-| **v1.1+** | Dashboard i18n — full UI translation (~1,600 strings, 5 locales) | 16-20 days | Reach ++ | Phase 10: Reach |
-| | | | | |
-| **ICEBOX** | Method complexity analysis (Q) | 1 day | Unique + | Deferred |
-| **ICEBOX** | GitHub App with check runs (requires OAuth flow) | 3-5 days | Enterprise + | Deferred |
-| **ICEBOX** | PR comments warning about errors (requires GitHub App) | 2-3 days | DX ++ | Deferred |
-| **ICEBOX** | CODEOWNERS-based auto-assignment | 1-2 days | Workflow + | Deferred |
-| **ICEBOX** | Bidirectional comment sync (complex, fragile) | 3-5 days | Workflow + | Deferred |
+### Shipped, by release
 
----
+| Release | Date | Headline |
+|---------|------|----------|
+| v0.2–v0.3 | Dec 2025 – Feb 2026 | Capture, dedup, notifications, health panels, flexible auth, dependency reduction (9 → 2) |
+| v0.4.0 | Mar 2026 | TracePoint era — local variables, instance variables, swallowed-exception detection, crash capture, diagnostic dump, Rack Attack, YJIT/RubyVM stats |
+| v0.5.x | Mar – Apr 2026 | ActionCable monitoring, issue trackers (GitHub/GitLab/Codeberg), release tracking, user impact scoring, scheduled digests, production code-path coverage |
+| v0.6.x | Apr – May 2026 | Stored-XSS fix ([GHSA-4rwp-83g9-78gv](https://github.com/AnjanJ/rails_error_dashboard/security/advisories/GHSA-4rwp-83g9-78gv)), hardening |
+| v0.7.x | May – Jun 2026 | LLM observability — call breadcrumbs, tool-call tracking, per-model health page, LLM context in Copy-for-LLM |
+| v0.8.0–v0.8.2 | Jun 2026 | Outbound OpenTelemetry export + self-instrumentation, Linear issue tracker, storm protection (circuit breaker + adaptive sampling) |
+| v0.8.3–v0.8.4 | Jul – Aug 2026 | Rack Attack persistence independent of error capture, missing-gem diagnostics, pagination locale isolation |
+| v0.9.0 | Aug 23 2026 | **Internationalization — eleven locales**, plus authenticating every dashboard controller |
+| v0.9.1 | Aug 24 2026 | Default-credential allowlist ([GHSA-qhgm-3pxf-mvc6](https://github.com/AnjanJ/rails_error_dashboard/security/advisories/GHSA-qhgm-3pxf-mvc6)) |
+
+Note the shape: the first three quarters were feature build-out (156 commits in March alone), the
+last two months are hardening and correctness (20 commits in August, but both security advisories
+and two releases). That shift is deliberate. Depth before breadth.
+
+### Next up
+
+| When | Item | State |
+|------|------|-------|
+| **v0.10.0** | Rack::Attack track discriminator, count loss, shutdown flush, AI-agent classification | **PR #177 — all 19 checks green, MERGEABLE, held on purpose.** Two releases already shipped on 2026-08-24; this is a minor with a migration and wants its own release rather than a third same-day one. Merging it closes the loop owed to issue #170 |
+| **v0.10.0** | Chart date axes ignored the locale; horizontal bar chart axis titles inverted | **PR #179**, closes #178. Found by @gmarziou during the French locale review (#158) — a user-visible i18n bug affecting all eleven locales. Ships alongside #177 so both of that reporter's findings land in one release |
+| **Unblocked now** | Submit to awesome-ruby (21) | 30K download bar cleared at 37,381 — see Tier 5 |
+| **Waiting** | CVE ID for GHSA-qhgm-3pxf-mvc6 | Reporter owed an email once assigned |
+| **Community-owned** | Native-speaker review of 10 locales (#156–#165) | Open by design — the contribution path, not a backlog |
+
+### Open, uncommitted
+
+Nothing below is scheduled. These are the genuine remaining candidates, in rough order of appeal:
+
+| Item | Effort | Impact | Note |
+|------|--------|--------|------|
+| Telegram notifications (7a) | Half day | Adoption ++ | Only competitive gap vs Faultline that still stands |
+| Environment awareness (9) | 1 day | Team workflow ++ | Sharpened by the v0.9.1 advisory — we now care a lot about which environment we are in |
+| Health check endpoint (14) | Half day | Maturity signal + | "Who watches the watchmen" |
+| Webhook HMAC signatures (20) | Half day | Security + | Standard practice for outbound webhooks |
+| Zeitwerk boot-error capture (T) | Half day | Reliability + | |
+| ActiveStorage service health (U) | Half day | Operational + | |
+| Missing-translation tracking | Half day | Unique ++ | Newly relevant — we now ship 11 locales and have a private I18n backend to hook |
+| Lazy backtrace via `Thread.each_caller_location` (Y) | Half day | Performance + | |
+| Smarter grouping controls (7) | 2-3 days | Power users ++ | Custom fingerprint lambda done; merge/split UI is not |
+| RBAC (11) | 2-3 days | Enterprise ++ | |
+| Audit logging (12) | 1 day | Enterprise ++ | |
+| Comparison mode (19) | 1-2 days | Analytics ++ | |
+| AI error summaries (16) | 2-3 days | Buzz +++ | |
+| Inline fix suggestions (18) | 2-3 days | DX ++ | |
+| Full Context Error Report — unified view | 3-5 days | Flagship +++ | The v1.0 anchor |
+| PostgreSQL partitioning / TimescaleDB generator | 1-3 days | Scale ++ | |
+| Rollup/summary tables | 1-2 days | Performance +++ | |
+
+### Icebox
+
+JSON API · method complexity analysis (Q) · performance monitoring / APM (Z) · GitHub App with
+check runs · PR comments warning about errors · CODEOWNERS auto-assignment · bidirectional comment
+sync. All deferred for want of demand, not feasibility — except (Z), which is deferred on
+principle (see its entry above).
 
 ## Internal Audit Summary (Current Strengths & Weaknesses)
+
+> Scores are the maintainer's own judgement, not a benchmark. Figures verified 2026-08-25.
 
 ### What's Strong Today
 - Error capture & deduplication (9/10) — SHA256 hashing, smart normalization, custom fingerprint, auto-reopen, cause chain
 - Error context (9.5/10) — request (HTTP method, hostname, duration, params), job, platform, user (CurrentAttributes), git SHA, environment info, sensitive data filtering, local/instance variables (TracePoint), breadcrumbs, system health snapshot
-- Configuration (9/10) — 100+ options, sensible defaults, env var support, comprehensive validation, default credentials protection
+- Configuration (9/10) — 127 options, sensible defaults, env var support, comprehensive validation, default-credential allowlist
 - Error lifecycle (8.5/10) — 5 states, assignment, priority, snooze, mute/unmute, comments, batch ops, auto-reopen on recurrence
 - Notifications (8.5/10) — 5 channels (Slack, Email, Discord, PagerDuty, Webhooks), severity filter, per-error cooldown, threshold milestones, mute suppression, plugin callbacks
 - Analytics (8/10) — baseline alerts, similar errors, cascades, correlation, patterns
 - Deep debugging (9/10) — local variable capture, instance variable capture, swallowed exception detection, process crash capture, diagnostic dump, Rack Attack tracking, ActionCable monitoring
 - System health (9/10) — GC stats + context, process memory (RSS/peak/swap), file descriptors, system load, system memory, TCP connections, DB pool, Puma, job queue, RubyVM, YJIT
 - Copy for LLM (9/10) — source code snippets, filtered variables omitted, conditional sections, signal-to-noise optimized for AI debugging
+- LLM observability (9/10) — call breadcrumbs, tool-call tracking, per-model health page, OTel span ingestion
+- OpenTelemetry (9/10) — inbound (spans → breadcrumbs) and outbound (gem operations → spans), plus self-instrumentation so users can verify the overhead budget themselves
+- Storm protection (9/10) — circuit breaker + adaptive sampling for error floods (v0.8.2)
+- Internationalization (7.5/10) — eleven locales, isolated private backend, mechanical verification via `bin/i18n-check`. Held back from higher only because ten of the eleven are machine-translated and unreviewed
 - Search & filtering (8/10) — 11 filters, PostgreSQL full-text search, pagination
 - Source code integration (8/10) — source reader, git blame, GitHub links
 - Multi-tenancy (8/10) — per-app isolation, auto-detection, shared DB
 - Deployment (8/10) — 3-step install, works with Thruster, API-only mode, MySQL + PostgreSQL + SQLite supported
 - Dependencies (9/10) — only 2 required (pagy, groupdate), 4 optional with graceful degradation
-- Community (growing) — 5 contributors, 11 merged PRs, 11K+ downloads, 70+ stars
+- Testing (9.5/10) — 4,174 examples across 240 spec files, 18-phase chaos suite (~893 assertions), full CI matrix of Ruby 3.2–3.4 × Rails 7.0–8.1, plus system, integration and upgrade-path jobs
+- Community (growing) — 8 contributors, 49 merged PRs, 37,381 downloads, 90 stars
 
 ### What Needs Work
 - API (3/10) — no JSON endpoints at all (ICEBOX)
 - User management (7/10) — HTTP Basic Auth + custom lambda (Devise/Warden/session), no RBAC yet
-- ~~Local variables (0/10)~~ — **DONE (v0.4.0)** — TracePoint(:raise) locals + instance vars + swallowed detection
-- Integrations (8/10) — GitHub/GitLab/Codeberg issue tracking (manual + auto-create + lifecycle sync + webhooks), no Telegram (Faultline has this), sketch-level plugins
-- Performance monitoring (0/10) — no request timing or slow query tracking (findbug has this, planned v0.6)
-- Dashboard performance (7.5/10) — no rollup tables, no partitioning guidance. BRIN indexes added. See [TIMESERIES_ANALYSIS.md](TIMESERIES_ANALYSIS.md)
-- Testing (9.5/10) — 2800+ unit specs, 7 system tests, 1264+ chaos test assertions
-- Community growth — Ruby Toolbox PR submitted ([rubytoolbox/catalog#1033](https://github.com/rubytoolbox/catalog/pull/1033), awaiting merge). awesome-ruby requires 30K+ downloads (we're at ~11K) — not eligible yet
+- Integrations (8.5/10) — four issue trackers (GitHub/GitLab/Codeberg/Linear) with manual + auto-create + lifecycle sync + webhooks. **No Telegram** — the one competitive gap vs Faultline that still stands
+- Translation quality (unscored) — ten locales are machine-translated and unreviewed. Mechanically verified, honestly labelled, but a native speaker has reviewed none of them. Issues #156–#165 are the open invitation
+- Performance monitoring (0/10) — no request timing or slow query tracking. Deferred on principle, not backlog (see Z)
+- Dashboard performance (7.5/10) — no rollup tables, no partitioning guidance. BRIN + functional indexes added
+- Environment awareness (4/10) — errors carry a Rails env string, but there is no first-class filtering, badging or per-environment notification rule. The v0.9.1 advisory made this gap feel larger than it reads
+- Community growth — Ruby Toolbox PR still open ([rubytoolbox/catalog#1033](https://github.com/rubytoolbox/catalog/pull/1033)). awesome-ruby's 30K download bar is **now cleared** (37,381) and submission is unblocked but not done
 
-### What Was Fixed (v0.2 Quick Wins)
-- ~~Auto-reopen (0/10)~~ — Now auto-reopens resolved/wont_fix errors on recurrence
-- ~~Notifications (7.5/10)~~ — Now has severity filter, per-error cooldown, threshold milestones
-- ~~Request context (7/10)~~ — Now captures HTTP method, hostname, content type, request duration
-- ~~Dependencies (6/10)~~ — Reduced from 9 required to 2 (pagy, groupdate) + optional
-- ~~Sensitive data~~ — Filters passwords, tokens, credit cards, SSNs by default (24 built-in patterns)
-- ~~Error context~~ — Exception cause chain, environment info, CurrentAttributes, custom fingerprint, structured backtrace
-- ~~UX~~ — Backtrace line numbers (PR #69), loading states & skeleton screens with Stimulus controller (PR #71)
+### Security Track Record
+Two advisories published, both reported by outside researchers, both fixed and released within a day:
+- [GHSA-4rwp-83g9-78gv](https://github.com/AnjanJ/rails_error_dashboard/security/advisories/GHSA-4rwp-83g9-78gv) (2026-05-04) — stored XSS in `resolution_comment` rendering
+- [GHSA-qhgm-3pxf-mvc6](https://github.com/AnjanJ/rails_error_dashboard/security/advisories/GHSA-qhgm-3pxf-mvc6) (2026-08-24, high) — default credentials accepted outside production. CVE ID still pending
+
+A third hardening fix, authenticating every dashboard controller rather than only `ErrorsController`
+(#167), shipped in v0.9.0 without an advisory — it was found internally before disclosure.


### PR DESCRIPTION
`ROADMAP.md` was last updated at v0.7.0 in May. It had drifted from stale into actively misleading.

## Roadmap

**Four dead links.** The header named `HOST_APP_SAFETY.md`, `DEEP_INTROSPECTION_ANALYSIS.md`, `FAULTLINE_COMPARISON.md` and `TIMESERIES_ANALYSIS.md` as required reading. All four are in `.gitignore` (lines 55–59) and were never committed — those links have been broken for every reader of the public repo since they were written. Removed, with a note on where the safety rules actually live.

**Every figure was wrong.** Re-verified against RubyGems and the GitHub API: downloads 11,000 → **37,381**, stars 70 → **90**, specs "2800+" → **4,174 across 240 files**, config options 100+ → **127**, contributors 5 → **8**, merged PRs 11 → **49**.

**The priority matrix had become fiction.** It still targeted i18n at "v1.1+" — it shipped in v0.9.0. It listed v0.5/v0.6 features done since spring. Replaced ~100 lines of struck-through history with a shipped-by-release table, a "next up" table, and an honest unscheduled list.

**Status changes worth calling out:**

- Items 8 and 24 marked DONE. Item 24 records *why* the first implementation was insufficient, since "done" alone would hide that it became GHSA-qhgm-3pxf-mvc6.
- **awesome-ruby (21) flipped from ineligible to unblocked** — its 30K download bar is now cleared at 37,381. By the roadmap's own words, the "single highest-leverage action for visibility."
- Added environment awareness at 4/10 to "What Needs Work". Previously unscored, and the v0.9.1 advisory was fundamentally an environment-awareness bug.

## Safety skill

Four incidents and the competitor section existed **only** in the uncommitted `HOST_APP_SAFETY.md`, recoverable from a single backup tarball. Now committed: Sentry #1246, SolidQueue #271, Mailboxer #480, Puma PR #2767, plus the Sentry/Honeybadger/Bugsnag safety mechanisms. Source links added to all eleven incidents — the original seven had none.

Cross-checking the skill against shipped code turned up three inconsistencies, which is the part worth reviewing:

1. **The checklist contradicted the code.** It banned `ObjectSpace` outright, but `DiagnosticDumpGenerator` deliberately uses `ObjectSpace.count_objects` (O(1), no heap walk) *while citing "banned rule #8"*. The author knew the distinction; the skill didn't record it.
2. **A real rule was never written down.** The same file avoids `Thread.list.map(&:backtrace)` because it holds the GVL. Now rule 11.
3. **"Existing Known Issues" was misleading twice over** — all three were fixed, and the paths pointed at `app/` when the files live under `lib/rails_error_dashboard/`. Rewritten as the three memory-bounding patterns to copy, since the fixes teach better than the bugs did.

Risk ratings were pre-implementation estimates for features that all shipped; reframed as a map of where the danger already lives, with storm protection, Rack::Attack and OTel export added.

## Testing

Documentation only — no code paths touched. Verified no dead relative links remain, table column counts are consistent per table, and the skill's YAML frontmatter still parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)