### PR TITLE
docs: refresh counts and roadmap status after v0.10.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ rails_error_dashboard is a self-hosted error tracking gem for Rails. It's a Rail
 ## Architecture Rules
 
 1. **HOST APP SAFETY FIRST** — Never raise in capture path, never block requests, budget every operation, clean up Thread.current, always re-raise original exceptions
-2. **CQRS** — Commands for writes (`app/commands/`), Queries for reads (`app/queries/`), Services for algorithms (`app/services/`)
+2. **CQRS** — Commands for writes (`lib/rails_error_dashboard/commands/`), Queries for reads (`lib/rails_error_dashboard/queries/`), Services for algorithms (`lib/rails_error_dashboard/services/`)
 3. **NEVER depend on Rails asset pipeline** — no Sprockets, no Propshaft, no `app/assets/`, no `public/` directory serving
 4. All CSS is inline in the layout `<style>` block, all JS is inline in `<script>` blocks
 5. External dependencies (Bootstrap JS for tooltips/modals, Chart.js, Highlight.js) loaded via CDN only — Bootstrap CSS was removed in v0.6.0 in favor of a custom design token system
@@ -19,7 +19,7 @@ rails_error_dashboard is a self-hosted error tracking gem for Rails. It's a Rail
 
 ### RSpec (unit/integration)
 ```bash
-bundle exec rspec                          # full suite (~3636 specs, ~53s)
+bundle exec rspec                          # full suite (~4,280 specs)
 bundle exec rspec spec/system/             # system tests (Capybara + Cuprite)
 HEADLESS=false bundle exec rspec spec/system/  # visible browser
 ```
@@ -56,9 +56,9 @@ Skip all hooks: `LEFTHOOK=0 git commit -m "msg"`
 | `lib/rails_error_dashboard/` | Core gem code |
 | `lib/rails_error_dashboard/engine.rb` | Engine setup, middleware, subscriber |
 | `lib/rails_error_dashboard/configuration.rb` | 100+ config options |
-| `app/commands/rails_error_dashboard/` | CQRS commands (writes) |
-| `app/queries/rails_error_dashboard/` | CQRS queries (reads) |
-| `app/services/rails_error_dashboard/` | Services (algorithms) |
+| `lib/rails_error_dashboard/commands/` | CQRS commands (writes) |
+| `lib/rails_error_dashboard/queries/` | CQRS queries (reads) |
+| `lib/rails_error_dashboard/services/` | Services (algorithms) |
 | `app/views/rails_error_dashboard/` | Dashboard views (ERB) |
 | `spec/` | RSpec tests |
 | `test/pre_release/` | Chaos test scripts + templates |

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ gem 'rails_error_dashboard'
 
 **[rails-error-dashboard.anjan.dev](https://rails-error-dashboard.anjan.dev)** — Username: `gandalf` · Password: `youshallnotpass`
 
-> **Beta Software** — Functional and tested (2,700+ tests passing), but the API may change before v1.0. Supports Rails 7.0-8.1 and Ruby 3.2-4.0.
+> **Beta Software** — Functional and tested (4,200+ tests passing), but the API may change before v1.0. Supports Rails 7.0-8.1 and Ruby 3.2-4.0.
 
 ### Screenshots
 
@@ -709,7 +709,7 @@ Built with **CQRS (Command/Query Responsibility Segregation)**:
 
 ## Testing
 
-2,600+ tests covering unit, integration, and browser-based system tests.
+4,200+ tests covering unit, integration, and browser-based system tests.
 
 ```bash
 bundle exec rspec                              # Full suite

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Rails Error Dashboard — Roadmap
 
-> Last updated: August 25, 2026 | Current version: v0.9.1 | Next: v0.10.0 (PR #177, held)
+> Last updated: August 26, 2026 | Current version: v0.10.0 | Next: v0.10.1 (PR #184, open)
 >
 > **Working analysis docs are local-only, by design.** Earlier revisions of this file linked to
 > `DEEP_INTROSPECTION_ANALYSIS.md`, `FAULTLINE_COMPARISON.md`, `TIMESERIES_ANALYSIS.md` and
@@ -292,7 +292,7 @@ Environment:
 - **Implementation:** `ActiveSupport::Notifications.subscribe("throttle.rack_attack")`, guard with `defined?(Rack::Attack)`, store as breadcrumbs or dedicated counter
 - **Effort:** Half day
 - **Impact:** Operational + (useful if Rack Attack is installed)
-- **Reworked three times since.** v0.8.3 (#143) made events persist independently of error capture — they were previously lost unless an error happened to fire. v0.8.4 (#150) surfaced a missing `rack-attack` gem instead of failing silently. **v0.10.0 (PR #177, held)** fixes the remaining three defects found via issue [#170](https://github.com/AnjanJ/rails_error_dashboard/issues/170): `track` events never set a discriminator (so "Unique IPs" always read 0 next to a real count), counts were silently lost on LRU eviction, and there was no flush on shutdown. It also adds AI-agent classification from the User-Agent header
+- **Reworked three times since.** v0.8.3 (#143) made events persist independently of error capture — they were previously lost unless an error happened to fire. v0.8.4 (#150) surfaced a missing `rack-attack` gem instead of failing silently. **v0.10.0 (#177, shipped 2026-08-25)** fixes the remaining three defects found via issue [#170](https://github.com/AnjanJ/rails_error_dashboard/issues/170): `track` events never set a discriminator (so "Unique IPs" always read 0 next to a real count), counts were silently lost on LRU eviction, and there was no flush on shutdown. It also adds AI-agent classification from the User-Agent header
 
 ### S. ActionCable Connection Monitoring -- DONE (v0.5.0)
 - **What:** Track WebSocket connection counts, channel actions, transmissions, subscription confirmations/rejections. Surface ActionCable health alongside errors
@@ -349,7 +349,7 @@ Environment:
 - **What shipped:** A private I18n backend isolated from the host app, request-scoped locale state, the `red_t` helper family, plural/relative-time/date-format helpers, a dynamic `<html lang>`, the full ~1,500-key extraction across views, inline JS, mailers and notification payloads, a JS translation payload, a session-persisted language picker, and `bin/i18n-check` to verify locale files mechanically. **Eleven locales ship** — `en` (source) plus `de`, `es`, `fr`, `pt-BR`, `ja`, `ru`, `uk`, `pl`, `it` and `zh-CN`
 - **Translation quality is explicitly unreviewed.** Every non-English locale is machine-translated, because the maintainer reads only English. `bin/i18n-check` enforces what a script can verify — key parity, interpolation variables, CLDR plural categories — and the English fallback means a wrong translation degrades to English rather than a broken page. Wording, register and idiom are labelled unreviewed rather than pretended away
 - **Open follow-up:** issues [#156–#165](https://github.com/AnjanJ/rails_error_dashboard/issues/156) — one per locale, tagged `good first issue` / `translation:needs-review`, inviting native speakers to correct wording. These stay open by design; they are the contribution path, not a backlog
-- **That path has already paid for itself.** The first reviewer to take one up (@gmarziou, French, #158) reported not a wording problem but two real bugs: chart date axes rendering in English in every locale, and inverted axis titles on the horizontal bar chart — plus a latent third (issue #178, fixed in PR #179). Worth stating plainly, because `bin/i18n-check` could not have caught any of it: it verifies key structure, interpolation variables and plural categories, not what reaches a `<canvas>`. **A locale can pass every mechanical check and still render English on every chart.** When auditing i18n coverage, grep for `strftime` and `to_json` in views, not only for missing `red_t` calls — data serialized to JS is the blind spot
+- **That path has already paid for itself.** The first reviewer to take one up (@gmarziou, French, #158) reported not a wording problem but two real bugs: chart date axes rendering in English in every locale, and inverted axis titles on the horizontal bar chart — plus a latent third (issue #178, fixed in #179, shipped in v0.10.0). Worth stating plainly, because `bin/i18n-check` could not have caught any of it: it verifies key structure, interpolation variables and plural categories, not what reaches a `<canvas>`. **A locale can pass every mechanical check and still render English on every chart.** When auditing i18n coverage, grep for `strftime` and `to_json` in views, not only for missing `red_t` calls — data serialized to JS is the blind spot
 - **Two follow-up fixes landed after the release:** pagination rendering in the dashboard's own locale (v0.8.4, #152) and authenticating every dashboard controller rather than only `ErrorsController` (v0.9.0, #167)
 - **Demand signal:** still no user request and zero i18n issues filed before the work started. It proceeded because the foundation made it incremental, not because demand appeared
 - **Effort (actual):** foundation 2-3 days · extraction + tooling ~14 days · locales ~4 days · verification and release ~2 days
@@ -602,7 +602,7 @@ All overhead numbers validated against Sentry's production benchmarks and Ruby d
 
 ### Where we actually are
 
-Nine months, 654 commits, 78 published versions, currently **v0.9.1**. The version-by-version
+Nine months, 655 commits, 80 published versions, currently **v0.10.0**. The version-by-version
 table that used to live here had gone stale in a way that made it actively misleading — it still
 targeted i18n at "v1.1+" months after it shipped in v0.9.0, and listed features at v0.5/v0.6 that
 had been done since spring. It has been replaced by the shipped history below plus a short,
@@ -621,17 +621,18 @@ honest forward list.
 | v0.8.3–v0.8.4 | Jul – Aug 2026 | Rack Attack persistence independent of error capture, missing-gem diagnostics, pagination locale isolation |
 | v0.9.0 | Aug 23 2026 | **Internationalization — eleven locales**, plus authenticating every dashboard controller |
 | v0.9.1 | Aug 24 2026 | Default-credential allowlist ([GHSA-qhgm-3pxf-mvc6](https://github.com/AnjanJ/rails_error_dashboard/security/advisories/GHSA-qhgm-3pxf-mvc6)) |
+| v0.10.0 | Aug 25 2026 | Rack::Attack `track` discriminator, count loss on eviction, shutdown flush, AI-agent classification (#177, closes #170); localized chart date axes and corrected horizontal bar chart axis titles (#179, closes #178) |
 
 Note the shape: the first three quarters were feature build-out (156 commits in March alone), the
-last two months are hardening and correctness (20 commits in August, but both security advisories
-and two releases). That shift is deliberate. Depth before breadth.
+last two months are hardening and correctness (21 commits in August, but a security advisory
+and three releases). That shift is deliberate. Depth before breadth.
 
 ### Next up
 
 | When | Item | State |
 |------|------|-------|
-| **v0.10.0** | Rack::Attack track discriminator, count loss, shutdown flush, AI-agent classification | **PR #177 — all 19 checks green, MERGEABLE, held on purpose.** Two releases already shipped on 2026-08-24; this is a minor with a migration and wants its own release rather than a third same-day one. Merging it closes the loop owed to issue #170 |
-| **v0.10.0** | Chart date axes ignored the locale; horizontal bar chart axis titles inverted | **PR #179**, closes #178. Found by @gmarziou during the French locale review (#158) — a user-visible i18n bug affecting all eleven locales. Ships alongside #177 so both of that reporter's findings land in one release |
+| **v0.10.1** | System specs no longer touch the network (host-level blocking, vendored scripts); dashboard no longer scrolls sideways on a 375px phone | **PR #184**, refs #183. Started as a CI-flake fix and surfaced a real mobile layout bug: navbar flex items never shrank and four inline `repeat(3, 1fr)` stat grids could not carry a media query. All 19 checks green |
+| **Verifying** | v0.10.0 fixes for #170 and #178 | Shipped 2026-08-25. Both issues deliberately left open for @gmarziou to confirm and close |
 | **Unblocked now** | Submit to awesome-ruby (21) | 30K download bar cleared at 37,381 — see Tier 5 |
 | **Waiting** | CVE ID for GHSA-qhgm-3pxf-mvc6 | Reporter owed an email once assigned |
 | **Community-owned** | Native-speaker review of 10 locales (#156–#165) | Open by design — the contribution path, not a backlog |

--- a/_features/source-code-integration.md
+++ b/_features/source-code-integration.md
@@ -764,7 +764,7 @@ Source code is loaded on-demand:
 
 ### Test Coverage
 
-- **Total Tests:** 2,600+ tests (as of v0.4.0)
+- **Total Tests:** 4,200+ tests (as of v0.10.0)
 - **New Tests:** 150+ tests for source code integration
 - **Coverage:** 64.6% overall, 100% for all new services and helpers
 - **Status:** All tests passing ✅

--- a/_getting_started/features.md
+++ b/_getting_started/features.md
@@ -1048,7 +1048,7 @@ config.enable_source_code_integration = true # Source code viewer (NEW!)
 config.enable_git_blame = true               # Git blame integration (NEW!)
 ```
 
-*All code is complete and tested (2,600+ tests passing). These advanced features provide powerful insights for production debugging.*
+*All code is complete and tested (4,200+ tests passing). These advanced features provide powerful insights for production debugging.*
 
 ### Fuzzy Error Matching
 - **Find similar errors** even with different error hashes

--- a/_reference/glossary.md
+++ b/_reference/glossary.md
@@ -353,7 +353,7 @@ Security vulnerability where unwanted attributes are updated. Rails protects wit
 ## Testing
 
 ### RSpec
-Ruby testing framework. Rails Error Dashboard has 2,600+ tests covering models, controllers, services, and integration.
+Ruby testing framework. Rails Error Dashboard has 4,200+ tests covering models, controllers, services, and integration.
 
 ### Factory Bot
 Test data generation. Creates realistic test records for errors, applications, and users.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1160,7 +1160,7 @@ config.enable_source_code_integration = true # Source code viewer (NEW!)
 config.enable_git_blame = true               # Git blame integration (NEW!)
 ```
 
-*All code is complete and tested (2,600+ tests passing). These advanced features provide powerful insights for production debugging.*
+*All code is complete and tested (4,200+ tests passing). These advanced features provide powerful insights for production debugging.*
 
 ### Fuzzy Error Matching
 - **Find similar errors** even with different error hashes

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -359,7 +359,7 @@ Security vulnerability where unwanted attributes are updated. Rails protects wit
 ## Testing
 
 ### RSpec
-Ruby testing framework. Rails Error Dashboard has 2,600+ tests covering models, controllers, services, and integration.
+Ruby testing framework. Rails Error Dashboard has 4,200+ tests covering models, controllers, services, and integration.
 
 ### Factory Bot
 Test data generation. Creates realistic test records for errors, applications, and users.

--- a/docs/SOURCE_CODE_INTEGRATION.md
+++ b/docs/SOURCE_CODE_INTEGRATION.md
@@ -764,7 +764,7 @@ Source code is loaded on-demand:
 
 ### Test Coverage
 
-- **Total Tests:** 2,600+ tests (as of v0.4.0)
+- **Total Tests:** 4,200+ tests (as of v0.10.0)
 - **New Tests:** 150+ tests for source code integration
 - **Coverage:** 64.6% overall, 100% for all new services and helpers
 - **Status:** All tests passing ✅


### PR DESCRIPTION
Docs only. Brings the roadmap, README, CLAUDE.md and six doc pages back in line with what shipped on 2026-08-25.

## What was stale

- **ROADMAP.md** still said *current v0.9.1, next v0.10.0 (PR #177, held)* a day after 0.10.0 was on RubyGems, and its "Next up" table listed #177 and #179 as pending. Both shipped.
- **Test count** read 2,600–2,700+ in **eight** places against 4,278 examples on `main` — README (×2), `docs/GLOSSARY.md`, `docs/FEATURES.md`, `docs/SOURCE_CODE_INTEGRATION.md`, and their Jekyll mirrors under `_reference/`, `_getting_started/`, `_features/`. Found by grepping content, not filenames.
- **CLAUDE.md** pointed the CQRS layers at `app/commands|queries|services/`, which don't exist; the code is under `lib/rails_error_dashboard/`. Spec count said ~3636.

## Numbers, verified not estimated

| Claim | Source | Value |
|---|---|---|
| Commits | `git rev-list --count main` | 655 |
| Published versions | RubyGems versions API | 80 |
| Examples | `rspec --dry-run` on main | 4,278 (docs say "4,200+" so they age gracefully) |
| August | `git log --since=2026-08-01` | 21 commits, one advisory, three releases |

Dropped the "~53s" suite timing from CLAUDE.md rather than guess — only the count was measured.

"Next up" now points at #184 (→ v0.10.1) and lists #170 / #178 as awaiting reporter verification.

Refs #184.