### PR TITLE
ci(release): give Ferrum 30s to start Chrome before publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,11 @@ jobs:
 
       - name: Run tests before publishing
         if: ${{ steps.release.outputs.release_created }}
+        env:
+          # Same as test.yml: Ferrum defaults to 10s waiting for Chrome's websocket
+          # URL and a cold runner can exceed it. The 0.11.1 release run failed on
+          # exactly this (Ferrum::ProcessTimeoutError) with nothing wrong in the gem.
+          FERRUM_PROCESS_TIMEOUT: 30
         run: bundle exec rspec
 
       - name: Run RuboCop before publishing
@@ -98,6 +103,11 @@ jobs:
           bundler-cache: true
 
       - name: Run tests before publishing
+        env:
+          # Same as test.yml: Ferrum defaults to 10s waiting for Chrome's websocket
+          # URL and a cold runner can exceed it. The 0.11.1 release run failed on
+          # exactly this (Ferrum::ProcessTimeoutError) with nothing wrong in the gem.
+          FERRUM_PROCESS_TIMEOUT: 30
         run: bundle exec rspec
 
       - name: Run RuboCop before publishing


### PR DESCRIPTION
The 0.11.1 Release run (33071771955) failed its pre-publish `rspec` step on `Ferrum::ProcessTimeoutError` — the cold-runner flake that `test.yml:102` already guards with `FERRUM_PROCESS_TIMEOUT: 30`. `release.yml` never set it, so the publish gate was flakier than the PR gate. This sets it on both the automated `release` job and the `workflow_dispatch` `republish` job.

No code or version change (`ci:` — release-please does not bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)