### PR TITLE
fix: classify GitHub Copilot, and render the RubyGems description as RDoc

### DIFF
--- a/_guides/configuration.md
+++ b/_guides/configuration.md
@@ -938,7 +938,7 @@ If `rack-attack` is not loaded, a startup warning is logged and no events are re
 
 ### Measuring AI crawler traffic (v0.10.0)
 
-Events record the client's user agent, and known AI agents are named on the dashboard — `GPTBot`, `ChatGPT-User`, `OAI-SearchBot`, `ClaudeBot`, `Claude-User`, `Claude Code`, `PerplexityBot`, `Bytespider`, `CCBot` and others, alongside ordinary crawlers such as Googlebot so the two can be told apart. The page shows an **AI Agent Requests** total and a **Top Agent** column per rule.
+Events record the client's user agent, and known AI agents are named on the dashboard — `GPTBot`, `ChatGPT-User`, `OAI-SearchBot`, `ClaudeBot`, `Claude-User`, `Claude Code`, `PerplexityBot`, `GitHub Copilot`, `Bytespider`, `CCBot` and others, alongside ordinary crawlers such as Googlebot so the two can be told apart. The page shows an **AI Agent Requests** total and a **Top Agent** column per rule.
 
 `Rack::Attack.track` rules are the way to feed it. They count matching requests without blocking or throttling anything:
 
@@ -946,7 +946,7 @@ Events record the client's user agent, and known AI agents are named on the dash
 # Who is reading the site, regardless of the format they ask for
 Rack::Attack.track("ai agents") do |req|
   ua = req.user_agent.to_s
-  req.ip if ua.match?(/GPTBot|ChatGPT-User|OAI-SearchBot|ClaudeBot|Claude-User|Claude-Code|PerplexityBot/i)
+  req.ip if ua.match?(/GPTBot|ChatGPT-User|OAI-SearchBot|ClaudeBot|Claude-User|Claude-Code|PerplexityBot|GitHubCopilot/i)
 end
 
 # Who specifically wants Markdown

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -972,7 +972,7 @@ If `rack-attack` is not loaded, a startup warning is logged and no events are re
 
 ### Measuring AI crawler traffic (v0.10.0)
 
-Events record the client's user agent, and known AI agents are named on the dashboard — `GPTBot`, `ChatGPT-User`, `OAI-SearchBot`, `ClaudeBot`, `Claude-User`, `Claude Code`, `PerplexityBot`, `Bytespider`, `CCBot` and others, alongside ordinary crawlers such as Googlebot so the two can be told apart. The page shows an **AI Agent Requests** total and a **Top Agent** column per rule.
+Events record the client's user agent, and known AI agents are named on the dashboard — `GPTBot`, `ChatGPT-User`, `OAI-SearchBot`, `ClaudeBot`, `Claude-User`, `Claude Code`, `PerplexityBot`, `GitHub Copilot`, `Bytespider`, `CCBot` and others, alongside ordinary crawlers such as Googlebot so the two can be told apart. The page shows an **AI Agent Requests** total and a **Top Agent** column per rule.
 
 `Rack::Attack.track` rules are the way to feed it. They count matching requests without blocking or throttling anything:
 
@@ -980,7 +980,7 @@ Events record the client's user agent, and known AI agents are named on the dash
 # Who is reading the site, regardless of the format they ask for
 Rack::Attack.track("ai agents") do |req|
   ua = req.user_agent.to_s
-  req.ip if ua.match?(/GPTBot|ChatGPT-User|OAI-SearchBot|ClaudeBot|Claude-User|Claude-Code|PerplexityBot/i)
+  req.ip if ua.match?(/GPTBot|ChatGPT-User|OAI-SearchBot|ClaudeBot|Claude-User|Claude-Code|PerplexityBot|GitHubCopilot/i)
 end
 
 # Who specifically wants Markdown

--- a/lib/rails_error_dashboard/services/ai_agent_classifier.rb
+++ b/lib/rails_error_dashboard/services/ai_agent_classifier.rb
@@ -31,7 +31,26 @@ module RailsErrorDashboard
         "Claude-User" => /Claude-User/i,
         "Claude Code" => /Claude-?Code/i,
         "Perplexity-User" => /Perplexity-User/i,
-        "Gemini-User" => /Gemini-User/i
+        "Gemini-User" => /Gemini-User/i,
+        # Observed in production traffic by the reporter of #170:
+        # "GitHubCopilotRuntime-WebFetch", 7 requests from 5 IPs. Classified as
+        # an assistant rather than a crawler because it fetches a specific URL a
+        # developer's Copilot session asked for, one page at a time — not a bulk
+        # corpus crawl.
+        #
+        # The pattern is deliberately anchored on "GitHubCopilot" rather than a
+        # bare /Copilot/i. Microsoft applies the Copilot brand very broadly, and
+        # its Copilot features are documented as riding Bingbot infrastructure or
+        # sending ordinary Edge/Chromium user agents with no bot signal — so a
+        # loose pattern would mislabel plain browser traffic as an AI agent,
+        # which is exactly the wrong-attribution failure this class avoids.
+        #
+        # No authoritative UA documentation exists for this agent: it is absent
+        # from GitHub's own docs, from ai-robots-txt/ai.robots.txt, and from the
+        # Dark Visitors catalogue as of 2026-08-29. The pattern therefore matches
+        # only what has actually been observed, plus the "-WebFetch" sibling
+        # suffix, instead of guessing at variants.
+        "GitHub Copilot" => /GitHubCopilot/i
       }.freeze
 
       AI_CRAWLERS = {

--- a/rails_error_dashboard.gemspec
+++ b/rails_error_dashboard.gemspec
@@ -6,29 +6,66 @@ Gem::Specification.new do |spec|
   spec.authors     = [ "Anjan Jagirdar" ]
   spec.email       = [ "anjan.jagirdar@gmail.com" ]
   spec.homepage    = "https://AnjanJ.github.io/rails_error_dashboard"
-spec.summary     = "Rails-native, self-hosted error monitoring with exception-time Ruby state, " \
-                   "runtime health, and storm-safe capture."
-spec.description = "Rails Error Dashboard (RED) is an open-source, self-hosted Rails engine for " \
-                   "investigating production exceptions without sending error data to a monitoring " \
-                   "vendor. It groups errors and records request context and cause chains and, when " \
-                   "enabled, breadcrumbs plus local and instance variables captured before Ruby " \
-                   "unwinds the stack. " \
-                   "RED attaches Rails and Ruby runtime health to the error record on every captured " \
-                   "occurrence, including Active Record pool, Puma, background jobs, GC, memory, " \
-                   "threads, file descriptors and system pressure. Built-in storm protection " \
-                   "progressively sheds expensive context and I/O during error floods while " \
-                   "retaining useful exemplars and exact occurrence counts. " \
-                   "Run RED with your application's database or an isolated error database. It " \
-                   "supports PostgreSQL, MySQL/Trilogy and SQLite, and includes workflow, " \
-                   "notifications (Slack, Email, Discord, PagerDuty, webhooks), two-way issue sync " \
-                   "with GitHub, GitLab, Codeberg and Linear, Copy as RSpec/curl/LLM, " \
-                   "swallowed-exception detection, LLM observability without prompt capture, " \
-                   "OpenTelemetry span export and Rails-specific operational views. The dashboard " \
-                   "is translated into 11 languages (machine-translated outside English, awaiting " \
-                   "native review). A self-hosted Sentry alternative that keeps error data in your " \
-                   "own database. The gem is MIT and free forever. Supports Rails 7.0-8.1 and " \
-                   "Ruby 3.2-4.0. Beta: APIs may change before 1.0. " \
-                   "Live demo: https://rails-error-dashboard.anjan.dev"
+  spec.summary     = "Rails-native, self-hosted error monitoring with exception-time Ruby state, " \
+                     "runtime health, and storm-safe capture."
+
+  # HOW RUBYGEMS.ORG RENDERS THIS — do not reformat without re-reading.
+  #
+  # rubygems.org's RubygemsHelper#simple_markup gates on the regexp
+  #
+  #     /^==+ [A-Z]/
+  #
+  # If it matches, the text is rendered through RDoc::Markup: headings,
+  # paragraphs, bullet lists and auto-linked URLs. If it does NOT match, the
+  # entire description is dumped into one <p> — the cramped wall of text with an
+  # unclickable demo link that this gem shipped for months.
+  #
+  # The anchor is ^, so a heading must begin at COLUMN 0. An earlier attempt used
+  # <<~DESC with the body indented two spaces past its terminator; <<~ strips
+  # only the *common* indentation, so every line retained two leading spaces, the
+  # regexp never matched, and that "fix" would have rendered exactly as broken as
+  # the text it replaced. Hence <<-DESC with the content flush left.
+  #
+  # spec/gemspec_description_spec.rb asserts the gate matches and that the
+  # rendered HTML really contains headings, a list and an anchor tag.
+  spec.description = <<-DESC
+== Rails-native failure investigation
+
+Rails Error Dashboard (RED) is an open-source, self-hosted Rails engine for
+investigating production exceptions without sending error data to a monitoring
+vendor. It groups errors and records request context and cause chains and, when
+enabled, breadcrumbs plus local and instance variables captured before Ruby
+unwinds the stack.
+
+== What it records
+
+* Rails and Ruby runtime health on the error record, refreshed on every captured
+  occurrence: Active Record pool, Puma, background jobs, GC, memory, threads,
+  file descriptors and system pressure
+* Built-in storm protection that progressively sheds expensive context and I/O
+  during error floods while retaining useful exemplars and exact occurrence
+  counts
+* Copy as RSpec, curl or LLM prompt; swallowed-exception detection; LLM
+  observability without prompt capture; OpenTelemetry span export
+* Workflow, notifications (Slack, Email, Discord, PagerDuty, webhooks) and
+  two-way issue sync with GitHub, GitLab, Codeberg and Linear
+* Rails-specific operational views: jobs, database, cache, Action Cable, Active
+  Storage, Rack::Attack and deprecations
+
+== Running it
+
+Run RED with your application's database or an isolated error database, on
+PostgreSQL, MySQL/Trilogy or SQLite. The dashboard is translated into 11
+languages (machine-translated outside English, awaiting native review). A
+self-hosted Sentry alternative that keeps error data in your own database. The
+gem is MIT and free forever.
+
+Supports Rails 7.0-8.1 and Ruby 3.2-4.0. Beta: APIs may change before 1.0.
+
+Live demo: https://rails-error-dashboard.anjan.dev
+
+Documentation: https://AnjanJ.github.io/rails_error_dashboard
+  DESC
   spec.license     = "MIT"
   spec.required_ruby_version = ">= 3.2.0"
 

--- a/spec/gemspec_description_spec.rb
+++ b/spec/gemspec_description_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rdoc"
+
+# Guards how rubygems.org renders this gem's description.
+#
+# WHY THIS EXISTS: the gem page showed one cramped wall of text with an
+# unclickable demo link for months, and more than one attempt to fix it failed
+# silently — the gemspec looked formatted in the editor while the published page
+# was unchanged, because nothing here could tell the difference.
+#
+# rubygems.org's RubygemsHelper#simple_markup does exactly this:
+#
+#     if /^==+ [A-Z]/.match?(text)
+#       sanitize RDoc::Markup.new.convert(text, RDoc::Markup::ToHtml.new(pipe: true))
+#     else
+#       tag.p(escape_once(sanitize(text.strip)))
+#     end
+#
+# So the whole outcome hinges on one anchored regexp. These examples reproduce
+# that gate and the RDoc conversion rather than asserting on the source text,
+# because "the gemspec contains == headings" was true of the broken version too.
+RSpec.describe "gemspec description rendering on rubygems.org" do
+  # The published gate, copied verbatim from rubygems.org.
+  RUBYGEMS_RDOC_GATE = /^==+ [A-Z]/
+
+  let(:spec) do
+    Gem::Specification.load(File.expand_path("../rails_error_dashboard.gemspec", __dir__))
+  end
+
+  let(:description) { spec.description }
+
+  let(:rendered) do
+    RDoc::Markup.new.convert(description, RDoc::Markup::ToHtml.new(pipe: true))
+  end
+
+  it "loads the gemspec" do
+    expect(spec).to be_a(Gem::Specification)
+    expect(description).not_to be_empty
+  end
+
+  describe "the RDoc gate" do
+    it "matches, so the page renders as RDoc rather than a single paragraph" do
+      expect(description).to match(RUBYGEMS_RDOC_GATE)
+    end
+
+    # The regexp is anchored at ^, so a heading indented by even one space is
+    # invisible to it. This is the exact defect that made a previous fix a no-op:
+    # <<~HEREDOC strips only the COMMON indentation, so a body indented past its
+    # terminator keeps leading spaces on every line.
+    it "starts its headings at column 0" do
+      heading_lines = description.lines.grep(/^\s*==+ /)
+
+      expect(heading_lines).not_to be_empty
+      heading_lines.each do |line|
+        expect(line).to start_with("=="),
+          "heading is indented, which defeats /^==+ [A-Z]/: #{line.inspect}"
+      end
+    end
+
+    it "would not render as one cramped paragraph" do
+      # The else-branch of simple_markup: everything in a single <p>.
+      expect(rendered.scan(/<p>/).size).to be > 1
+    end
+  end
+
+  describe "the rendered HTML" do
+    it "has section headings" do
+      expect(rendered.scan(/<h\d/).size).to be >= 3
+    end
+
+    it "has a bullet list" do
+      expect(rendered.scan(/<li>/).size).to be >= 3
+    end
+
+    # The reported symptom: "the live demo link is not clickable at all".
+    it "renders the live demo URL as a real anchor" do
+      expect(rendered).to include('<a href="https://rails-error-dashboard.anjan.dev">')
+    end
+
+    it "renders the documentation URL as a real anchor" do
+      expect(rendered).to match(%r{<a href="https://AnjanJ\.github\.io/rails_error_dashboard"})
+    end
+  end
+
+  describe "the summary" do
+    # RubyGems warns above 255 and the value is truncated in listings.
+    it "stays within the length RubyGems displays" do
+      expect(spec.summary.length).to be <= 255
+    end
+
+    it "is a single line" do
+      expect(spec.summary).not_to include("\n")
+    end
+  end
+end

--- a/spec/gemspec_description_spec.rb
+++ b/spec/gemspec_description_spec.rb
@@ -31,8 +31,31 @@ RSpec.describe "gemspec description rendering on rubygems.org" do
 
   let(:description) { spec.description }
 
+  # RDoc's ToHtml constructor changed shape across the versions this gem supports.
+  # Modern RDoc (8.x) takes keywords (pipe:, output_decoration:) — the form
+  # rubygems.org itself calls. RDoc 6.x, which resolves alongside Rails 7.0, takes
+  # a positional RDoc::Options.
+  #
+  # The trap: on RDoc 6.x the keyword call does NOT raise. `pipe: true` is
+  # accepted as a positional Hash and stored as @options, and the failure only
+  # surfaces later, mid-conversion, as
+  #   NoMethodError: undefined method 'output_decoration' for an instance of Hash
+  # So rescuing around the constructor alone is useless — the rescue has to wrap
+  # the CONVERSION. That is what broke this spec on all three Rails 7.0 jobs.
   let(:rendered) do
+    convert_with_keywords
+  rescue ArgumentError, NoMethodError, TypeError
+    convert_with_options_object
+  end
+
+  def convert_with_keywords
     RDoc::Markup.new.convert(description, RDoc::Markup::ToHtml.new(pipe: true))
+  end
+
+  def convert_with_options_object
+    options = RDoc::Options.new
+    options.pipe = true if options.respond_to?(:pipe=)
+    RDoc::Markup.new.convert(description, RDoc::Markup::ToHtml.new(options))
   end
 
   it "loads the gemspec" do
@@ -76,7 +99,10 @@ RSpec.describe "gemspec description rendering on rubygems.org" do
 
     # The reported symptom: "the live demo link is not clickable at all".
     it "renders the live demo URL as a real anchor" do
-      expect(rendered).to include('<a href="https://rails-error-dashboard.anjan.dev">')
+      # Match the href only. RDoc versions differ in the anchor's link TEXT
+      # (6.x strips the scheme), so asserting on the full tag would pass on one
+      # supported Rails and fail on another without the link being any less real.
+      expect(rendered).to match(%r{<a href="https://rails-error-dashboard\.anjan\.dev"})
     end
 
     it "renders the documentation URL as a real anchor" do

--- a/spec/lib/rails_error_dashboard/services/ai_agent_classifier_spec.rb
+++ b/spec/lib/rails_error_dashboard/services/ai_agent_classifier_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe RailsErrorDashboard::Services::AiAgentClassifier do
     {
       "ChatGPT-User/1.0; +https://openai.com/bot" => :ai_assistant,
       "Claude-User/1.0" => :ai_assistant,
+      "GitHubCopilotRuntime-WebFetch" => :ai_assistant,
       "Mozilla/5.0 (compatible; GPTBot/1.2; +https://openai.com/gptbot)" => :ai_crawler,
       "Mozilla/5.0 (compatible; ClaudeBot/1.0; +claudebot@anthropic.com)" => :ai_crawler,
       "PerplexityBot/1.0" => :ai_crawler,
@@ -79,6 +80,36 @@ RSpec.describe RailsErrorDashboard::Services::AiAgentClassifier do
     it "never raises on a non-string input" do
       expect { described_class.kind(Object.new) }.not_to raise_error
       expect(described_class.kind(Object.new)).to eq(:other)
+    end
+  end
+
+  # Reported from production traffic on issue #170: 7 requests from 5 IPs.
+  # Absent from GitHub's docs, ai-robots-txt/ai.robots.txt and Dark Visitors as
+  # of 2026-08-29, so the pattern matches observed reality rather than a guess.
+  describe "GitHub Copilot" do
+    it "names the observed runtime agent and counts it as AI" do
+      ua = "GitHubCopilotRuntime-WebFetch"
+
+      expect(described_class.name(ua)).to eq("GitHub Copilot")
+      expect(described_class.kind(ua)).to eq(:ai_assistant)
+      expect(described_class.ai?(ua)).to be true
+    end
+
+    it "matches other GitHubCopilotRuntime suffixes" do
+      expect(described_class.name("GitHubCopilotRuntime/1.0")).to eq("GitHub Copilot")
+    end
+
+    # A bare /Copilot/i would swallow ordinary browser traffic: Microsoft applies
+    # the Copilot brand broadly, and its agentic features are documented as
+    # sending plain Edge/Chromium user agents with no bot signal. Mislabelling a
+    # human's browser as an AI agent is exactly the wrong-attribution failure the
+    # classifier exists to avoid.
+    it "does not claim unrelated Copilot-branded browser traffic" do
+      edge = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120.0 Edg/120.0"
+
+      expect(described_class.ai?(edge)).to be false
+      expect(described_class.kind(edge)).to eq(:browser)
+      expect(described_class.ai?("Mozilla/5.0 Copilot")).to be false
     end
   end
 end


### PR DESCRIPTION
Two independent patch fixes, both surfaced by issue #170.

---

## 1. Count GitHub Copilot in the AI agent total (`cd1540c`)

The reporter of #170 found `GitHubCopilotRuntime-WebFetch` in live production traffic — 7 requests from 5 IPs. `AiAgentClassifier` didn't know it, so it fell through to `:other`: displayed as a raw UA string, and — the part that matters — scored `ai? => false`, keeping it **out of the dashboard's "AI Agent Requests" total**. That total is the number they're using to decide whether to build markdown views, so an unrecognised assistant silently undercounts the exact signal the feature exists to measure.

Classified as an **assistant**, not a crawler: it fetches a specific URL a developer's Copilot session asked for, one page at a time, rather than bulk-fetching a corpus.

**The pattern is anchored on `GitHubCopilot`, not a bare `/Copilot/i`.** Microsoft applies the Copilot brand very broadly, and its Copilot features are documented as riding Bingbot infrastructure or sending ordinary Edge/Chromium user agents with no bot signal at all. A loose pattern would label a human's browser as an AI agent — the wrong-attribution failure this class was built to avoid. There's a spec pinning `Mozilla/5.0 … Edg/120` as `:browser`.

No authoritative UA documentation exists for this agent. It's absent from GitHub's own docs, from `ai-robots-txt/ai.robots.txt`, and from the Dark Visitors catalogue (checked 2026-08-29; the `copilot-user` page 404s). The pattern therefore covers what has actually been observed plus the sibling runtime suffix, rather than guessing at variants.

Why this is a `fix` and not a `feat`: the classifier, the AI total and the Top Agent column all shipped in 0.10.0. A missing entry in a list those features already depend on, which causes real traffic to be excluded from a total, is a defect — not new capability.

---

## 2. Render the RubyGems description as RDoc (`e32ad47`)

The gem page has shown the entire description as one unbroken paragraph with the live demo URL as **unclickable plain text**. This has been attempted more than once and never worked.

### Why every previous attempt failed

rubygems.org's `RubygemsHelper#simple_markup` decides everything on one regexp:

```ruby
if /^==+ [A-Z]/.match?(text)
  sanitize RDoc::Markup.new.convert(text, RDoc::Markup::ToHtml.new(pipe: true))
else
  tag.p(escape_once(sanitize(text.strip)))   # the cramped wall of text
end
```

The anchor is `^`, so **a heading must begin at column 0**.

The previous attempt (`f83c3f5`, on the never-merged branch `chore/gemspec-rdoc-description`) used `<<~DESC` with the body indented two spaces past its terminator. `<<~` strips only the *common* indentation, so every line kept two leading spaces, the regexp never matched, and that change would have published **exactly the same cramped paragraph it was written to fix**. Verified directly: the indented text gates `false`, the flush-left text gates `true`.

That also explains why this kept looking fixed — the gemspec read as formatted in the editor, and nothing in the suite could tell formatted from unformatted.

### The fix

`<<-DESC` with content flush left. RDoc auto-links bare URLs, so the demo and documentation links become real anchors with no markup.

Rendered through RubyGems' exact pipeline: **3 headings, 5 bullets, 10 paragraphs, 2 anchors**, including `<a href="https://rails-error-dashboard.anjan.dev">`.

### The guard

`spec/gemspec_description_spec.rb` asserts on the **converted HTML**, not the gemspec source. That distinction is the point: "the file contains `==` headings" was true of the broken version too, which is exactly why the suite never caught this. It checks the gate, that headings start at column 0, and that the output really contains headings, list items and the demo anchor.

Verified the guard catches the regression: re-indenting the description by two spaces fails the heading, list and demo-link examples.

---

## Test plan

- Full suite: **4379 examples, 0 failures, 1 pending** (+14). RuboCop clean.
- `Gem::Specification.load` succeeds; description gates `true` against the verbatim rubygems.org regexp.
- rubygems.org's helper source read directly from `rubygems/rubygems.org@master` rather than assumed.
- The docs regex was extracted programmatically from the published guide and exercised: matches `GitHubCopilotRuntime-WebFetch`, `ChatGPT-User`, `Claude-Code`, `GPTBot`; does not match `Googlebot`, `curl` or a plain Chrome UA.
- Classifier negative cases asserted, not assumed: a Copilot-branded Edge UA stays `:browser` and `ai? => false`.

## Note

The gem page shows the **latest published version's** metadata, so fix 2 becomes visible only on the next release. The evidence it works is the rendering test, not the live page.

Both commits are typed `fix`, so release-please will cut a single patch.

Refs: #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q79vZjad87KbSPCXQTcHyR
