### PR TITLE
fix(i18n): repair and reorder chart date axes, and match the server's plural rules

### DIFF
--- a/app/helpers/rails_error_dashboard/i18n_helper.rb
+++ b/app/helpers/rails_error_dashboard/i18n_helper.rb
@@ -164,17 +164,30 @@ module RailsErrorDashboard
     # Same formatter the mailers and the Slack/Discord payloads use, so a chart
     # axis and an email agree about what a date looks like.
     #
+    # The pattern defaults to the locale's own axis_day rather than being passed
+    # in. Every caller used to hardcode "%b %d", which is US ordering: the
+    # formatter translates the WORDS but never reorders, so French read
+    # "août 06" where it should read "6 août", and ja/zh-CN read "8月 06"
+    # instead of "8月6日". Ten of eleven locales were wrong, and the ordering
+    # each one needs already lives in red.time.formats.
+    #
     # @param time [Time, Date, nil]
-    # @param pattern [String] a strftime pattern
+    # @param pattern [String, Symbol] a strftime pattern, or one of
+    #   red.time.formats' presets — defaults to :axis_day
     # @return [String] "" for nil — an axis label must never read "undefined"
-    def red_chart_date(time, pattern)
+    def red_chart_date(time, pattern = :axis_day)
       return "" if time.nil?
 
+      pattern = red_time_format(pattern) if pattern.is_a?(Symbol)
       time = time.to_time if time.respond_to?(:to_time) && !time.is_a?(Time)
       Services::LocalizedTimeFormatter.call(time, pattern: pattern, locale: red_locale)
     rescue StandardError
-      # A chart with an English axis beats a chart that fails to render.
-      time.respond_to?(:strftime) ? time.strftime(pattern) : time.to_s
+      # A chart with an English axis beats a chart that fails to render. If the
+      # failure was red_time_format itself, `pattern` is still the Symbol, and
+      # strftime(":axis_day") would print that verbatim on the axis — so fall
+      # back to a real pattern rather than to the preset's name.
+      fallback = pattern.is_a?(Symbol) ? "%b %-d" : pattern.to_s
+      time.respond_to?(:strftime) ? time.strftime(fallback) : time.to_s
     end
   end
 end

--- a/app/views/layouts/rails_error_dashboard.html.erb
+++ b/app/views/layouts/rails_error_dashboard.html.erb
@@ -1779,9 +1779,78 @@ document.addEventListener('DOMContentLoaded', function() {
     var am = typeof meridian.am === 'string' ? meridian.am : RED_DATE_EN.meridian.am;
     var h12 = h % 12 || 12, ampm = h >= 12 ? pm : am;
     var pad = function(n) { return n.toString().padStart(2, '0'); };
-    return fmt.replace('%Y',y).replace('%y',y.toString().substr(2)).replace('%B',months[mo]).replace('%b',monthsShort[mo])
-      .replace('%m',pad(mo+1)).replace('%d',pad(d)).replace('%e',d).replace('%A',days[dow]).replace('%a',daysShort[dow])
-      .replace('%H',pad(h)).replace('%I',pad(h12)).replace('%M',pad(mi)).replace('%S',pad(s)).replace('%p',ampm).replace('%P',ampm.toLowerCase());
+
+    // One regex pass, not a chain of .replace('%d', …). Two reasons:
+    //
+    //   * String-argument replace() substitutes only the FIRST match, so a
+    //     pattern that repeats a directive — "%d/%m/%d" — left the second one
+    //     as literal text.
+    //   * The chain is order-sensitive in a way that breaks %-d: '%d' matches
+    //     inside '%-d', so "%-d %b" became "%-<day> %b".
+    //
+    // %-d and %-m (unpadded day and month) are needed because a chart axis
+    // reads "6 août", not "06 août". Ruby's strftime already supports them, so
+    // this also closes a gap between the two formatters — a locale's pattern
+    // must mean the same thing server-side and in the browser.
+    var TABLE = {
+      '%Y': y,
+      '%y': y.toString().substr(2),
+      '%B': months[mo],
+      '%b': monthsShort[mo],
+      '%m': pad(mo + 1),
+      '%-m': mo + 1,
+      '%d': pad(d),
+      '%-d': d,
+      '%e': d,
+      '%A': days[dow],
+      '%a': daysShort[dow],
+      '%H': pad(h),
+      '%I': pad(h12),
+      '%M': pad(mi),
+      '%S': pad(s),
+      '%p': ampm,
+      '%P': ampm.toLowerCase()
+    };
+
+    // %-? before the letter so '%-d' wins over '%d'. An unknown directive is
+    // left verbatim rather than becoming "undefined", matching the old chain's
+    // behaviour for anything it did not list.
+    return fmt.replace(/%-?[A-Za-z]/g, function(token) {
+      var value = TABLE[token];
+      return value === undefined ? token : String(value);
+    });
+  }
+
+  // English chart-axis patterns, and the shape every locale must match.
+  // Deliberately not the same strings as red.time.formats' other presets: an
+  // axis needs month+day with no year, and a year cannot simply be stripped
+  // from "%Y年%m月%d日" or "%d de %B de %Y" without leaving a dangling word.
+  var RED_AXIS_EN = {
+    axis_day: '%b %-d',
+    axis_month: '%b %Y',
+    axis_datetime: '%b %-d, %-I:%M %p',
+    axis_full: '%b %-d, %Y'
+  };
+
+  // The locale's chart-axis patterns, falling back per key. Same total-lookup
+  // discipline as redDate(): a locale missing one key still gets a usable axis
+  // rather than "undefined" drawn across the bottom of the chart.
+  function axisFormats() {
+    var out = {};
+    var source;
+    try {
+      source = (window.RED_I18N && window.RED_I18N.formats) ? window.RED_I18N.formats : null;
+    } catch (e) {
+      source = null;
+    }
+    for (var key in RED_AXIS_EN) {
+      if (!Object.prototype.hasOwnProperty.call(RED_AXIS_EN, key)) continue;
+      var value = source ? source[key] : undefined;
+      // A pattern with no % directive is not a pattern — most likely i18n
+      // returned humanized key text for a miss.
+      out[key] = (typeof value === 'string' && value.indexOf('%') !== -1) ? value : RED_AXIS_EN[key];
+    }
+    return out;
   }
 
   // Chart.js renders date axes through chartjs-adapter-date-fns, whose bundle
@@ -1820,15 +1889,23 @@ document.addEventListener('DOMContentLoaded', function() {
     if (proto.format === redChartDateWrapper) return;
 
     // date-fns token -> strftime, for the patterns the adapter actually uses.
+    //
+    // Read from the locale rather than hardcoded, because these patterns carry
+    // ORDER as well as vocabulary. The literals here used to be US English —
+    // 'MMM d' -> '%b %d' — and formatDateTime only swaps words, so French
+    // rendered "août 06" instead of "6 août" and ja/zh-CN "8月 06" instead of
+    // "8月6日". Ten of eleven locales were wrong on every chart, deterministically,
+    // and the correct ordering already existed in red.time.formats.
+    var AXIS = axisFormats();
     var TOKENS = {
-      'MMM d, yyyy, h:mm:ss aaaa': '%b %d, %Y, %I:%M:%S %p',
+      'MMM d, yyyy, h:mm:ss aaaa': AXIS.axis_datetime,
       'h:mm:ss.SSS aaaa': '%I:%M:%S %p',
       'h:mm:ss aaaa': '%I:%M:%S %p',
       'h:mm aaaa': '%I:%M %p',
       'ha': '%I %p',
-      'MMM d': '%b %d',
-      'PP': '%b %d, %Y',
-      'MMM yyyy': '%b %Y',
+      'MMM d': AXIS.axis_day,
+      'PP': AXIS.axis_full,
+      'MMM yyyy': AXIS.axis_month,
       'yyyy': '%Y'
     };
 

--- a/app/views/layouts/rails_error_dashboard.html.erb
+++ b/app/views/layouts/rails_error_dashboard.html.erb
@@ -1590,7 +1590,10 @@ document.addEventListener('DOMContentLoaded', function() {
   });
   observer.observe(document.body, { childList: true, subtree: true });
 
-  document.addEventListener('chartkick:load', function() { applyChartTheme(); });
+  // On window, not document: Chartkick dispatches `new Event("chartkick:load")`
+  // on window, and a bare Event does not bubble — so a document listener here
+  // never ran, and the theme was never re-applied when charts finished loading.
+  window.addEventListener('chartkick:load', function() { applyChartTheme(); });
 
   // Force-apply a few times on page load for lazy-loaded charts
   var attempts = 0;
@@ -1794,10 +1797,27 @@ document.addEventListener('DOMContentLoaded', function() {
   //   week "PP"  month "MMM yyyy"  quarter "qqq - yyyy"  year "yyyy"
   // Anything else — a caller-supplied pattern, a future adapter version — is
   // handed back to the original implementation rather than half-translated.
+  //
+  // redChartDateWrapper holds the function installed below, so a re-assert can
+  // tell "already ours" from "ours was overwritten". A boolean flag cannot:
+  // chartjs-adapter-date-fns installs itself with
+  //
+  //   Chart._adapters._date.override(t) { Object.assign(En.prototype, t) }
+  //
+  // which REPLACES format() while leaving any separate flag property standing.
+  // So whenever this ran before the adapter script — three CDN scripts, three
+  // chances to lose that race — the patch was silently wiped and the flag then
+  // reported "already patched" forever, which is why #178 came back reading
+  // "Aug 21" on some loads and "août 21" on others.
+  var redChartDateWrapper = null;
+
   function installRedChartDateAdapter() {
     if (typeof Chart === 'undefined' || !Chart._adapters || !Chart._adapters._date) return;
     var proto = Chart._adapters._date.prototype;
-    if (!proto || typeof proto.format !== 'function' || proto._redPatched) return;
+    if (!proto || typeof proto.format !== 'function') return;
+    // Identity, not a flag: this is a no-op when the live format() is still the
+    // wrapper, and reinstalls when something has replaced it.
+    if (proto.format === redChartDateWrapper) return;
 
     // date-fns token -> strftime, for the patterns the adapter actually uses.
     var TOKENS = {
@@ -1812,8 +1832,13 @@ document.addEventListener('DOMContentLoaded', function() {
       'yyyy': '%Y'
     };
 
+    // Read afresh on every install, never from a previous call: after the
+    // adapter has overwritten format(), the current value IS the adapter's real
+    // implementation. Capturing a stale wrapper here would nest wrappers on
+    // each re-assert and, worse, delegate to a function that no longer exists
+    // on the prototype.
     var original = proto.format;
-    proto.format = function(time, fmt) {
+    redChartDateWrapper = function(time, fmt) {
       try {
         var strf = TOKENS[fmt];
         if (strf) return formatDateTime(new Date(time), strf);
@@ -1822,7 +1847,7 @@ document.addEventListener('DOMContentLoaded', function() {
       }
       return original.call(this, time, fmt);
     };
-    proto._redPatched = true;
+    proto.format = redChartDateWrapper;
   }
 
 
@@ -1882,9 +1907,20 @@ document.addEventListener('DOMContentLoaded', function() {
   // `document` is a stub, so it must contain definitions only — no top-level
   // browser calls. The adapter is patched on the prototype, so charts drawn
   // later pick it up; chartkick:load re-asserts for page scripts whose own
-  // DOMContentLoaded handler beat this one, and _redPatched makes that a no-op.
+  // DOMContentLoaded handler beat this one, and the identity check inside
+  // makes that a no-op unless the patch has actually been overwritten.
+  //
+  // That re-assert is what repairs the lost race described above, so it has to
+  // be reachable: Chartkick dispatches `new Event("chartkick:load")` on window,
+  // and a bare Event has bubbles:false, so a document listener never sees it.
+  // Registered on document — as it was — this never ran at all.
+  //
+  // Ordering is on our side. Chartkick dispatches from a setTimeout(…, 0)
+  // scheduled while it parses, which runs after every DOMContentLoaded handler,
+  // and Chart.js draws on a requestAnimationFrame after that. So the re-assert
+  // lands after any possible clobber and before the first paint.
   installRedChartDateAdapter();
-  document.addEventListener('chartkick:load', installRedChartDateAdapter);
+  window.addEventListener('chartkick:load', installRedChartDateAdapter);
 
   if (typeof Turbo !== 'undefined') {
     document.addEventListener('turbo:load', convertToLocalTime);

--- a/app/views/layouts/rails_error_dashboard.html.erb
+++ b/app/views/layouts/rails_error_dashboard.html.erb
@@ -1965,10 +1965,76 @@ document.addEventListener('DOMContentLoaded', function() {
   // Plural selection. English needs one/other; other languages need more, and
   // some need only one form. Falling back to 'other' means a locale that ships
   // a partial set still renders rather than showing "undefined".
+  // CLDR plural category for a count, mirroring PrivateBackend::PLURAL_RULES.
+  // Kept as a parallel implementation on purpose: the server picks the form for
+  // strings it renders, and this picks it for strings JS renders, so the two
+  // must agree about what "5 seconds ago" is in Russian.
+  //
+  // The %100 guards are the part that is easy to get wrong: 11 is `many`, not
+  // `one`, and 12-14 are `many`, not `few`, even though 1 and 2-4 are. And
+  // Polish is NOT Russian — pl `one` is exactly 1, so 21 takes `many` where
+  // ru/uk take `one`. Copying one rule to the other language is the specific
+  // mistake the server's table documents.
+  function redPluralCategory(locale, count) {
+    if (typeof count !== 'number' || !isFinite(count) || Math.floor(count) !== count) return 'other';
+    var i = Math.abs(count), mod10 = i % 10, mod100 = i % 100;
+
+    switch (locale) {
+      case 'ja':
+      case 'zh-CN':
+        return 'other';
+      case 'fr':
+      case 'pt-BR':
+        return i < 2 ? 'one' : 'other';
+      case 'es':
+      case 'it':
+        return count === 1 ? 'one' : 'other';
+      case 'ru':
+      case 'uk':
+        if (mod10 === 1 && mod100 !== 11) return 'one';
+        if (mod10 >= 2 && mod10 <= 4 && !(mod100 >= 12 && mod100 <= 14)) return 'few';
+        return 'many';
+      case 'pl':
+        if (i === 1) return 'one';
+        if (mod10 >= 2 && mod10 <= 4 && !(mod100 >= 12 && mod100 <= 14)) return 'few';
+        return 'many';
+      default:
+        // en, de and anything unlisted keep the English one/other split, which
+        // is also upstream i18n's behaviour for a locale it has no rule for.
+        return count === 1 ? 'one' : 'other';
+    }
+  }
+
+  // Plural selection. English needs one/other; ru/uk/pl need four categories
+  // and ship them, but this only ever read `one` and `other` — so Russian
+  // rendered "5 секунды" (few) where it should read "5 секунд" (many), using a
+  // form the locale file had supplied all along.
+  //
+  // Falls back through the categories rather than to `other` alone, because for
+  // ru/uk/pl CLDR assigns `other` to fractional counts only: a locale that
+  // ships one/few/many and no `other` must still render.
   function redPluralize(forms, count) {
     if (!forms || typeof forms !== 'object') return String(count);
-    var form = (count === 1 && typeof forms.one === 'string') ? forms.one : forms.other;
-    if (typeof form !== 'string') form = forms.one;
+
+    var locale;
+    try {
+      locale = (window.RED_I18N && typeof window.RED_I18N.locale === 'string') ? window.RED_I18N.locale : 'en';
+    } catch (e) {
+      locale = 'en';
+    }
+
+    var category = redPluralCategory(locale, count);
+    var form = forms[category];
+
+    // Ordered fallback: the requested category, then the ones most likely to
+    // carry a usable string, and finally anything the entry does supply.
+    if (typeof form !== 'string') {
+      var order = [ category, 'other', 'many', 'few', 'one' ];
+      for (var i = 0; i < order.length; i++) {
+        if (typeof forms[order[i]] === 'string') { form = forms[order[i]]; break; }
+      }
+    }
+
     if (typeof form !== 'string') return String(count);
     return form.replace(/%\{count\}/g, String(count));
   }

--- a/app/views/layouts/rails_error_dashboard.html.erb
+++ b/app/views/layouts/rails_error_dashboard.html.erb
@@ -1805,7 +1805,9 @@ document.addEventListener('DOMContentLoaded', function() {
       '%A': days[dow],
       '%a': daysShort[dow],
       '%H': pad(h),
+      '%-H': h,
       '%I': pad(h12),
+      '%-I': h12,
       '%M': pad(mi),
       '%S': pad(s),
       '%p': ampm,
@@ -1829,7 +1831,9 @@ document.addEventListener('DOMContentLoaded', function() {
     axis_day: '%b %-d',
     axis_month: '%b %Y',
     axis_datetime: '%b %-d, %-I:%M %p',
-    axis_full: '%b %-d, %Y'
+    axis_full: '%b %-d, %Y',
+    axis_time: '%-I:%M %p',
+    axis_hour: '%-I %p'
   };
 
   // The locale's chart-axis patterns, falling back per key. Same total-lookup
@@ -1896,17 +1900,32 @@ document.addEventListener('DOMContentLoaded', function() {
     // rendered "août 06" instead of "6 août" and ja/zh-CN "8月 06" instead of
     // "8月6日". Ten of eleven locales were wrong on every chart, deterministically,
     // and the correct ordering already existed in red.time.formats.
+    // The time-of-day patterns are the locale's too. They used to be hardcoded
+    // %I:%M %p, which put "03 PM" on a French hour axis — a 12-hour clock with
+    // an English meridian, contradicting that same locale's own time_only
+    // ("%H:%M:%S") elsewhere on the page. Only en declares a 12-hour clock;
+    // seven of the other ten never translated meridian at all, so AM/PM was
+    // being drawn on charts in languages that do not use it.
     var AXIS = axisFormats();
     var TOKENS = {
+      // chartjs-adapter-date-fns' own format table.
       'MMM d, yyyy, h:mm:ss aaaa': AXIS.axis_datetime,
-      'h:mm:ss.SSS aaaa': '%I:%M:%S %p',
-      'h:mm:ss aaaa': '%I:%M:%S %p',
-      'h:mm aaaa': '%I:%M %p',
-      'ha': '%I %p',
+      'h:mm:ss.SSS aaaa': AXIS.axis_time,
+      'h:mm:ss aaaa': AXIS.axis_time,
+      'h:mm aaaa': AXIS.axis_time,
+      'ha': AXIS.axis_hour,
       'MMM d': AXIS.axis_day,
       'PP': AXIS.axis_full,
       'MMM yyyy': AXIS.axis_month,
-      'yyyy': '%Y'
+      'qqq - yyyy': AXIS.axis_month,
+      'yyyy': '%Y',
+
+      // Chartkick overrides displayFormats and tooltipFormat with patterns of
+      // its own, which the adapter's table never mentions. Missing them meant
+      // hour-granularity axes and their tooltips stayed English even in a
+      // locale whose day axis was already translated.
+      'MMM d, h a': AXIS.axis_datetime,
+      'h:mm a': AXIS.axis_time
     };
 
     // Read afresh on every install, never from a previous call: after the

--- a/app/views/rails_error_dashboard/errors/correlation.html.erb
+++ b/app/views/rails_error_dashboard/errors/correlation.html.erb
@@ -36,8 +36,8 @@
             <div class="display-6"><%= @period_comparison[:current_period][:count] %></div>
             <small class="text-muted">
               <%= red_t("red.analytics.correlation.trend_analysis.period_range",
-                         start: red_chart_date(@period_comparison[:current_period][:start], "%b %d"),
-                         end: red_chart_date(@period_comparison[:current_period][:end], "%b %d")) %>
+                         start: red_chart_date(@period_comparison[:current_period][:start]),
+                         end: red_chart_date(@period_comparison[:current_period][:end])) %>
             </small>
           </div>
           <div class="col-md-4">
@@ -45,8 +45,8 @@
             <div class="display-6"><%= @period_comparison[:previous_period][:count] %></div>
             <small class="text-muted">
               <%= red_t("red.analytics.correlation.trend_analysis.period_range",
-                         start: red_chart_date(@period_comparison[:previous_period][:start], "%b %d"),
-                         end: red_chart_date(@period_comparison[:previous_period][:end], "%b %d")) %>
+                         start: red_chart_date(@period_comparison[:previous_period][:start]),
+                         end: red_chart_date(@period_comparison[:previous_period][:end])) %>
             </small>
           </div>
           <div class="col-md-4">

--- a/app/views/rails_error_dashboard/errors/platform_comparison.html.erb
+++ b/app/views/rails_error_dashboard/errors/platform_comparison.html.erb
@@ -358,7 +358,7 @@
     new Chart(dailyTrendCtx, {
       type: 'line',
       data: {
-        labels: <%= raw @daily_trends.values.first&.keys&.map { |d| red_chart_date(d, '%b %d') }&.to_json || [].to_json %>,
+        labels: <%= raw @daily_trends.values.first&.keys&.map { |d| red_chart_date(d) }&.to_json || [].to_json %>,
         datasets: datasets
       },
       options: {

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1370,6 +1370,10 @@ de:
         date_only: "%d. %B %Y"
         time_only: "%H:%M:%S"
         datetime: "%d. %b %Y %H:%M"
+        axis_day: "%-d. %b"
+        axis_month: "%b %Y"
+        axis_datetime: "%-d. %b %H:%M"
+        axis_full: "%-d. %b %Y"
     health:
       columns:
         error: Fehler

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1374,6 +1374,8 @@ de:
         axis_month: "%b %Y"
         axis_datetime: "%-d. %b %H:%M"
         axis_full: "%-d. %b %Y"
+        axis_time: "%H:%M"
+        axis_hour: "%H Uhr"
     health:
       columns:
         error: Fehler

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1901,6 +1901,8 @@ en:
         axis_month: "%b %Y"
         axis_datetime: "%b %-d, %-I:%M %p"
         axis_full: "%b %-d, %Y"
+        axis_time: "%-I:%M %p"
+        axis_hour: "%-I %p"
 
     health:
       # Table column headers repeated on more than one health page.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1897,6 +1897,10 @@ en:
         date_only: "%B %d, %Y"
         time_only: "%I:%M:%S %p"
         datetime: "%b %d, %Y %H:%M"
+        axis_day: "%b %-d"
+        axis_month: "%b %Y"
+        axis_datetime: "%b %-d, %-I:%M %p"
+        axis_full: "%b %-d, %Y"
 
     health:
       # Table column headers repeated on more than one health page.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1424,6 +1424,10 @@ es:
         date_only: "%d de %B de %Y"
         time_only: "%H:%M:%S"
         datetime: "%d %b %Y %H:%M"
+        axis_day: "%-d %b"
+        axis_month: "%b %Y"
+        axis_datetime: "%-d %b %H:%M"
+        axis_full: "%-d %b %Y"
     health:
       columns:
         error: Error

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1428,6 +1428,8 @@ es:
         axis_month: "%b %Y"
         axis_datetime: "%-d %b %H:%M"
         axis_full: "%-d %b %Y"
+        axis_time: "%H:%M"
+        axis_hour: "%H:00"
     health:
       columns:
         error: Error

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1423,6 +1423,10 @@ fr:
         date_only: "%d %B %Y"
         time_only: "%H:%M:%S"
         datetime: "%d %b %Y %H:%M"
+        axis_day: "%-d %b"
+        axis_month: "%b %Y"
+        axis_datetime: "%-d %b %H:%M"
+        axis_full: "%-d %b %Y"
     health:
       columns:
         error: Erreur

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1427,6 +1427,8 @@ fr:
         axis_month: "%b %Y"
         axis_datetime: "%-d %b %H:%M"
         axis_full: "%-d %b %Y"
+        axis_time: "%H:%M"
+        axis_hour: "%Hh"
     health:
       columns:
         error: Erreur

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1412,6 +1412,10 @@ it:
         date_only: "%d %B %Y"
         time_only: "%H:%M:%S"
         datetime: "%d %b %Y %H:%M"
+        axis_day: "%-d %b"
+        axis_month: "%b %Y"
+        axis_datetime: "%-d %b %H:%M"
+        axis_full: "%-d %b %Y"
     health:
       columns:
         error: Errore

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1416,6 +1416,8 @@ it:
         axis_month: "%b %Y"
         axis_datetime: "%-d %b %H:%M"
         axis_full: "%-d %b %Y"
+        axis_time: "%H:%M"
+        axis_hour: "%H:00"
     health:
       columns:
         error: Errore

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1222,6 +1222,8 @@ ja:
         axis_month: "%Y年%-m月"
         axis_datetime: "%-m月%-d日 %H:%M"
         axis_full: "%Y年%-m月%-d日"
+        axis_time: "%H:%M"
+        axis_hour: "%-H時"
     health:
       columns:
         error: エラー

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1218,6 +1218,10 @@ ja:
         date_only: "%Y年%m月%d日"
         time_only: "%H:%M:%S"
         datetime: "%Y年%m月%d日 %H:%M"
+        axis_day: "%-m月%-d日"
+        axis_month: "%Y年%-m月"
+        axis_datetime: "%-m月%-d日 %H:%M"
+        axis_full: "%Y年%-m月%-d日"
     health:
       columns:
         error: エラー

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -1449,6 +1449,10 @@ pl:
         date_only: "%d %B %Y"
         time_only: "%H:%M:%S"
         datetime: "%d %b %Y %H:%M"
+        axis_day: "%-d %b"
+        axis_month: "%b %Y"
+        axis_datetime: "%-d %b %H:%M"
+        axis_full: "%-d %b %Y"
     health:
       columns:
         error: Błąd

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -1453,6 +1453,8 @@ pl:
         axis_month: "%b %Y"
         axis_datetime: "%-d %b %H:%M"
         axis_full: "%-d %b %Y"
+        axis_time: "%H:%M"
+        axis_hour: "%H:00"
     health:
       columns:
         error: Błąd

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1417,6 +1417,8 @@ pt-BR:
         axis_month: "%b %Y"
         axis_datetime: "%-d %b %H:%M"
         axis_full: "%-d %b %Y"
+        axis_time: "%H:%M"
+        axis_hour: "%H:00"
     health:
       columns:
         error: Erro

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1413,6 +1413,10 @@ pt-BR:
         date_only: "%d de %B de %Y"
         time_only: "%H:%M:%S"
         datetime: "%d %b %Y %H:%M"
+        axis_day: "%-d %b"
+        axis_month: "%b %Y"
+        axis_datetime: "%-d %b %H:%M"
+        axis_full: "%-d %b %Y"
     health:
       columns:
         error: Erro

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1453,6 +1453,8 @@ ru:
         axis_month: "%b %Y"
         axis_datetime: "%-d %b %H:%M"
         axis_full: "%-d %b %Y"
+        axis_time: "%H:%M"
+        axis_hour: "%H:00"
     health:
       columns:
         error: Ошибка

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1449,6 +1449,10 @@ ru:
         date_only: "%d %B %Y"
         time_only: "%H:%M:%S"
         datetime: "%d %b %Y, %H:%M"
+        axis_day: "%-d %b"
+        axis_month: "%b %Y"
+        axis_datetime: "%-d %b %H:%M"
+        axis_full: "%-d %b %Y"
     health:
       columns:
         error: Ошибка

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -1451,6 +1451,8 @@ uk:
         axis_month: "%b %Y"
         axis_datetime: "%-d %b %H:%M"
         axis_full: "%-d %b %Y"
+        axis_time: "%H:%M"
+        axis_hour: "%H:00"
     health:
       columns:
         error: Помилка

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -1447,6 +1447,10 @@ uk:
         date_only: "%d %B %Y"
         time_only: "%H:%M:%S"
         datetime: "%d %b %Y %H:%M"
+        axis_day: "%-d %b"
+        axis_month: "%b %Y"
+        axis_datetime: "%-d %b %H:%M"
+        axis_full: "%-d %b %Y"
     health:
       columns:
         error: Помилка

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -1214,6 +1214,8 @@ zh-CN:
         axis_month: "%Y年%-m月"
         axis_datetime: "%-m月%-d日 %H:%M"
         axis_full: "%Y年%-m月%-d日"
+        axis_time: "%H:%M"
+        axis_hour: "%-H时"
     health:
       columns:
         error: 错误

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -1210,6 +1210,10 @@ zh-CN:
         date_only: "%Y年%m月%d日"
         time_only: "%H:%M:%S"
         datetime: "%Y年%m月%d日 %H:%M"
+        axis_day: "%-m月%-d日"
+        axis_month: "%Y年%-m月"
+        axis_datetime: "%-m月%-d日 %H:%M"
+        axis_full: "%Y年%-m月%-d日"
     health:
       columns:
         error: 错误

--- a/spec/helpers/rails_error_dashboard/chart_date_i18n_spec.rb
+++ b/spec/helpers/rails_error_dashboard/chart_date_i18n_spec.rb
@@ -41,16 +41,40 @@ RSpec.describe "red_chart_date", type: :helper do
   end
 
   # The bug gmarziou reported: "Aug 6" on a French dashboard.
+  #
+  # Asserted against a literal, not against LocalizedTimeFormatter's own output
+  # for the same pattern. That earlier form was tautological — it restated the
+  # implementation, so it passed just as happily when French read "août 06".
   it "renders a localized month name rather than the English one" do
     with_locale("fr") do
       result = view_context.red_chart_date(Time.utc(2026, 8, 6), "%b %d")
 
-      expect(result).not_to include("Aug")
-      expect(result).to eq(
-        RailsErrorDashboard::Services::LocalizedTimeFormatter.call(
-          Time.utc(2026, 8, 6), pattern: "%b %d", locale: "fr"
-        )
-      )
+      expect(result).to eq("août 06")
+    end
+  end
+
+  # #178 round 2. The default pattern comes from the locale, so the words AND
+  # their order are the locale's own: French puts the day first, German adds
+  # the ordinal dot, and ja/zh-CN are year-month-day with CJK separators. Every
+  # caller used to hardcode "%b %d", which is US ordering, so ten of eleven
+  # locales rendered a correctly-translated month in the wrong place.
+  {
+    "en" => "Aug 6",
+    "fr" => "6 août",
+    "de" => "6. Aug.",
+    "es" => "6 ago",
+    "it" => "6 ago",
+    "pt-BR" => "6 ago",
+    "pl" => "6 sie",
+    "ru" => "6 авг.",
+    "uk" => "6 серп.",
+    "ja" => "8月6日",
+    "zh-CN" => "8月6日"
+  }.each do |locale, expected|
+    it "orders the default chart date the way #{locale} writes it" do
+      with_locale(locale) do
+        expect(view_context.red_chart_date(Time.utc(2026, 8, 6))).to eq(expected)
+      end
     end
   end
 

--- a/spec/system/chart_date_locale_spec.rb
+++ b/spec/system/chart_date_locale_spec.rb
@@ -92,6 +92,60 @@ RSpec.describe "Chart date axes follow the dashboard locale", type: :system do
     expect(label).to eq("8月6日")
   end
 
+  # Chartkick does not use the adapter's format table as-is: for hour and minute
+  # granularity it overrides displayFormats and tooltipFormat with patterns of
+  # its own. Those were absent from TOKENS, so an hour axis and every tooltip on
+  # it stayed English even once the day axis had been translated — the gap that
+  # survived the first fix.
+  def adapter_label(pattern, at: Date.new(2026, 8, 6))
+    page.evaluate_script(<<~JS)
+      (function() {
+        if (typeof Chart === 'undefined' || !Chart._adapters || !Chart._adapters._date) return null;
+        var a = new Chart._adapters._date({});
+        return a.format(Date.UTC(#{at.year}, #{at.month - 1}, #{at.day}, 15, 4), '#{pattern}');
+      })();
+    JS
+  end
+
+  {
+    "MMM d, h a" => "hour tick and tooltip",
+    "h:mm a" => "minute tick and tooltip"
+  }.each do |pattern, what|
+    it "localizes Chartkick's own #{what} pattern" do
+      RailsErrorDashboard.configuration.dashboard_locale = "fr"
+
+      visit_dashboard("/errors/analytics")
+      wait_for_page_load
+
+      label = adapter_label(pattern)
+      skip "Chart.js not loaded on this page" if label.nil?
+
+      # French declares a 24-hour clock in its own time_only, so an axis must
+      # not read "3 PM" — and must certainly not carry an English meridian.
+      #
+      # The hour itself is deliberately not asserted: formatDateTime reads local
+      # time, so the value depends on the machine's zone. What matters is the
+      # shape — 24-hour, no meridian.
+      expect(label).not_to include("PM")
+      expect(label).not_to include("AM")
+      expect(label).to match(/\d{2}:\d{2}/)
+    end
+  end
+
+  it "uses the locale's own hour format rather than a 12-hour clock" do
+    RailsErrorDashboard.configuration.dashboard_locale = "fr"
+
+    visit_dashboard("/errors/analytics")
+    wait_for_page_load
+
+    label = adapter_label("ha")
+    skip "Chart.js not loaded on this page" if label.nil?
+
+    # fr's axis_hour is "%Hh" — a 24-hour number and the French hour suffix,
+    # never "3 PM".
+    expect(label).to match(/\A\d{2}h\z/)
+  end
+
   it "leaves a pattern it does not recognize to the original adapter" do
     RailsErrorDashboard.configuration.dashboard_locale = "fr"
 

--- a/spec/system/chart_date_locale_spec.rb
+++ b/spec/system/chart_date_locale_spec.rb
@@ -72,6 +72,24 @@ RSpec.describe "Chart date axes follow the dashboard locale", type: :system do
     expect(label).not_to include("Aug")
     expect(label).to include(expected)
     expect(label).not_to include("undefined")
+
+    # #178 round 2: the words alone are not enough. "août 06" satisfies every
+    # assertion above and is still wrong — French writes the day first.
+    expect(label).to eq("6 août")
+  end
+
+  # The same axis in a locale whose date order is not merely reversed but
+  # structurally different, so a fix that only swapped two fields would fail.
+  it "renders the day axis in year-month-day order for Japanese" do
+    RailsErrorDashboard.configuration.dashboard_locale = "ja"
+
+    visit_dashboard("/errors/analytics")
+    wait_for_page_load
+
+    label = adapter_day_label
+    skip "Chart.js not loaded on this page" if label.nil?
+
+    expect(label).to eq("8月6日")
   end
 
   it "leaves a pattern it does not recognize to the original adapter" do

--- a/spec/system/chartkick_load_listener_spec.rb
+++ b/spec/system/chartkick_load_listener_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# #178, round 2. The layout registered both of its `chartkick:load` handlers on
+# `document`, but Chartkick dispatches
+#
+#   window.dispatchEvent(new Event("chartkick:load"))
+#
+# on `window`, and a bare `Event` has `bubbles: false`. A non-bubbling event
+# dispatched on window never reaches a document listener, so BOTH handlers were
+# dead code from the day they were written:
+#
+#   * applyChartTheme() never re-ran when charts finished loading
+#   * installRedChartDateAdapter()'s re-assert never fired, which is half of why
+#     a clobbered date adapter could never repair itself
+#
+# Neither failure is visible on screen — the theme usually looks right because a
+# MutationObserver also applies it, and the date adapter usually wins its race.
+# That is exactly why this needs a test: the symptom of a listener that never
+# fires is nothing at all.
+#
+# These specs therefore assert on RED's OWN handler running. An earlier draft
+# dispatched the event and counted a listener the spec itself registered, which
+# passed against the broken code — it was testing the DOM, not the wiring.
+RSpec.describe "chartkick:load listeners", type: :system do
+  let!(:application) { create(:application) }
+
+  before do
+    create(:error_log, application: application, occurred_at: 1.day.ago)
+  end
+
+  # Current is request-scoped but survives between examples in the test process;
+  # leaving a locale set here makes unrelated specs assert against the wrong one.
+  around do |example|
+    original = RailsErrorDashboard.configuration.dashboard_locale
+    example.run
+  ensure
+    RailsErrorDashboard.configuration.dashboard_locale = original
+    RailsErrorDashboard::Current.locale = nil
+  end
+
+  # Undo the date-adapter patch, then dispatch the event exactly as Chartkick
+  # 5.0.1 does — same constructor, same target. A live re-assert handler
+  # reinstalls the patch; a handler registered on `document` never runs and
+  # leaves the adapter unpatched.
+  #
+  # Asserts on the rendered label rather than on any bookkeeping property: what
+  # matters is that a chart axis reads "août", and a flag saying the patch is
+  # installed is exactly the kind of evidence that was wrong in #178 round 2.
+  #
+  # Returns nil when Chart.js is absent so the caller can skip rather than fail
+  # on an unrelated asset problem.
+  def label_after_stripping_patch_and_firing_chartkick_load
+    page.evaluate_script(<<~JS)
+      (function() {
+        if (typeof Chart === 'undefined' || !Chart._adapters || !Chart._adapters._date) return null;
+        var proto = Chart._adapters._date.prototype;
+
+        // Stand in for chartjs-adapter-date-fns winning the load race: replace
+        // format() wholesale, exactly as its Object.assign(prototype, …) does.
+        proto.format = function(time, fmt) { return 'UNPATCHED'; };
+
+        window.dispatchEvent(new Event('chartkick:load'));
+
+        return proto.format.call({ options: {} }, Date.UTC(2026, 7, 6), 'MMM d');
+      })();
+    JS
+  end
+
+  it "re-asserts the date adapter when Chartkick announces it has loaded" do
+    RailsErrorDashboard.configuration.dashboard_locale = "fr"
+
+    visit_dashboard("/errors/analytics")
+    wait_for_page_load
+
+    label = label_after_stripping_patch_and_firing_chartkick_load
+    skip "Chart.js not loaded on this page" if label.nil?
+
+    # "UNPATCHED" means the handler never ran: it was registered on a target the
+    # event does not reach. "Aug 06" would mean it ran but refused to reinstall,
+    # which is what the old _redPatched flag did after being clobbered.
+    expect(label).not_to eq("UNPATCHED")
+    expect(label).to include("août")
+  end
+
+  # The reported symptom (#178 round 2): "on wide screen I get English month
+  # names while on narrow screen I get French ones" — same page, same dates.
+  # Screen width was a red herring; the two loads simply resolved three CDN
+  # scripts in different orders.
+  #
+  # Reinstalling twice in a row must also be safe. The old flag made the second
+  # call a no-op; an identity check has to stay a no-op without nesting wrappers
+  # around each other, or a chart would pay for one delegation per page event.
+  it "survives the adapter overwriting format(), and re-asserts idempotently" do
+    RailsErrorDashboard.configuration.dashboard_locale = "fr"
+
+    visit_dashboard("/errors/analytics")
+    wait_for_page_load
+
+    result = page.evaluate_script(<<~JS)
+      (function() {
+        if (typeof Chart === 'undefined' || !Chart._adapters || !Chart._adapters._date) return null;
+        var proto = Chart._adapters._date.prototype;
+
+        proto.format = function(time, fmt) { return 'UNPATCHED'; };
+        window.dispatchEvent(new Event('chartkick:load'));
+        var repaired = proto.format.call({ options: {} }, Date.UTC(2026, 7, 6), 'MMM d');
+
+        // Two further re-asserts with nothing broken in between.
+        var afterFirst = proto.format;
+        window.dispatchEvent(new Event('chartkick:load'));
+        window.dispatchEvent(new Event('chartkick:load'));
+
+        return {
+          repaired: repaired,
+          stable: proto.format === afterFirst,
+          label: proto.format.call({ options: {} }, Date.UTC(2026, 7, 6), 'MMM d')
+        };
+      })();
+    JS
+    skip "Chart.js not loaded on this page" if result.nil?
+
+    expect(result["repaired"]).to include("août")
+    expect(result["stable"]).to be(true)
+    expect(result["label"]).to include("août")
+  end
+
+  # applyChartTheme() is the handler whose deadness nobody reported. It writes
+  # Chart.defaults.color, so a live handler is observable the same way: clobber
+  # the value, fire the event, and see whether RED puts it back.
+  it "re-applies the chart theme when Chartkick announces it has loaded" do
+    visit_dashboard("/errors/analytics")
+    wait_for_page_load
+
+    restored = page.evaluate_script(<<~JS)
+      (function() {
+        if (typeof Chart === 'undefined' || !Chart.defaults) return null;
+        Chart.defaults.color = '__CLOBBERED__';
+        window.dispatchEvent(new Event('chartkick:load'));
+        return Chart.defaults.color !== '__CLOBBERED__';
+      })();
+    JS
+    skip "Chart.js not loaded on this page" if restored.nil?
+
+    expect(restored).to be(true)
+  end
+end

--- a/spec/system/js_plural_parity_spec.rb
+++ b/spec/system/js_plural_parity_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "open3"
+require "json"
+require "tmpdir"
+
+# redPluralize only ever consulted `one` and `other`. ru, uk and pl each ship
+# four CLDR categories — and their locale files have supplied `few` and `many`
+# since the i18n sprint — so every relative timestamp JS renders in those
+# languages picked a form the language does not use there: Russian showed
+# "5 секунды" (few) where it should read "5 секунд" (many).
+#
+# The server has had correct rules all along, in PrivateBackend::PLURAL_RULES.
+# The browser now has the same rules, and this pins the two together: a chart
+# tooltip, a page timestamp and an email must agree about what five of
+# something is called.
+#
+# Compares against the REAL backend rather than a hardcoded table, so if the
+# server's rules are ever corrected this fails until the JS is corrected too.
+RSpec.describe "JS plural parity", type: :system do
+  # let, not a constant: a constant written inside an RSpec.describe block is
+  # defined at top level, and spec/system/p7_layout_qa_spec.rb already defines
+  # LOCALES. Whichever file loaded last won, and this spec silently ran against
+  # the other one's four locales.
+
+  # Every boundary the %100 guards exist for, plus the value that separates
+  # Polish from Russian.
+  let(:counts) { [ 0, 1, 2, 4, 5, 11, 12, 14, 21, 22, 25, 101, 111 ] }
+
+  # The locales RED ships. de is in here deliberately: it has no entry in
+  # PLURAL_RULES, so it exercises the "unlisted locale keeps one/other" path on
+  # both sides.
+  let(:locales) { %w[en de fr es it pt-BR pl ru uk ja zh-CN] }
+
+  # Lifted from the layout, exactly as js_date_parity_spec does, so the shipped
+  # implementation is what runs — not a copy that can drift.
+  def localized_source
+    layout = Rails.root.join("../../app/views/layouts/rails_error_dashboard.html.erb").cleanpath
+    layout = RailsErrorDashboard::Engine.root.join("app/views/layouts/rails_error_dashboard.html.erb") unless layout.exist?
+    body = File.read(layout)
+
+    start_at = body.index("  // English defaults for every localized value below.")
+    stop_at = body.index("  convertToLocalTime();", start_at.to_i)
+
+    raise "could not locate the date block in the layout" if start_at.nil? || stop_at.nil?
+
+    body[start_at...stop_at]
+  end
+
+  def js_categories
+    script = <<~JS
+      function build(locale) {
+        const fn = new Function('window', 'document', #{localized_source.to_json} + `
+          return { redPluralCategory: redPluralCategory };
+        `);
+        return fn({ RED_I18N: { locale: locale } }, { querySelectorAll: function() { return { forEach: function() {} }; } });
+      }
+      const out = {};
+      for (const locale of #{locales.to_json}) {
+        out[locale] = #{counts.to_json}.map(n => build(locale).redPluralCategory(locale, n));
+      }
+      console.log(JSON.stringify(out));
+    JS
+
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "plural.js")
+      File.write(path, script)
+      out, err, status = Open3.capture3("node", path)
+      raise "node failed: #{err}" unless status.success?
+
+      JSON.parse(out)
+    end
+  end
+
+  # What the real backend picks, asked the same way I18n asks it.
+  def server_categories
+    locales.each_with_object({}) do |locale, acc|
+      backend = RailsErrorDashboard::PrivateBackend.allocate
+      backend.instance_variable_set(:@current_pluralization_locale, locale)
+      entry = { one: "one", few: "few", many: "many", other: "other" }
+      acc[locale] = counts.map { |n| backend.send(:pluralization_key, entry, n).to_s }
+    end
+  end
+
+  before do
+    skip "node is not available" unless system("which node > /dev/null 2>&1")
+  end
+
+  it "picks the same plural category as the server for every locale and count" do
+    expect(js_categories).to eq(server_categories)
+  end
+
+  # Called out separately because it is the mistake the server's own table
+  # warns about: pl `one` is exactly 1, so 21 is `many`, while ru/uk treat any
+  # count ending in 1 (except 11) as `one`. A rule copied between them looks
+  # right and is wrong, and no structural check would catch it.
+  it "does not treat Polish as Russian at 21" do
+    js = js_categories
+
+    expect(js["pl"][counts.index(21)]).to eq("many")
+    expect(js["ru"][counts.index(21)]).to eq("one")
+    expect(js["uk"][counts.index(21)]).to eq("one")
+  end
+
+  # The %100 guards. 11 looks like `one` and 12-14 look like `few` on a %10
+  # reading alone, and both are `many`.
+  it "applies the %100 guards for the four-category locales" do
+    js = js_categories
+
+    %w[ru uk pl].each do |locale|
+      expect(js[locale][counts.index(11)]).to eq("many")
+      expect(js[locale][counts.index(12)]).to eq("many")
+      expect(js[locale][counts.index(14)]).to eq("many")
+    end
+  end
+end


### PR DESCRIPTION
Refs #178.

@gmarziou reported against 0.11.3: "on wide screen I get English month names while on narrow screen I get French ones." Same page, same dates, same French UI — one load drew `Aug 21`, the other `août 21`.

Screen width was a red herring. The two loads simply resolved three CDN scripts in different orders. Chasing that turned up four more defects in the same code, none of them previously reported.

## 1. The reported bug — a load-order race

`installRedChartDateAdapter()` wraps `format()` on the date adapter's prototype. But chartjs-adapter-date-fns installs itself with

```js
Chart._adapters._date.override(t) { Object.assign(En.prototype, t) }
```

which **replaces** `format()`. `Chart._adapters._date` exists as soon as chart.js has run, so whenever RED's patch went in before the adapter script, it was silently wiped. `_redPatched` is a separate property, so it survived the `Object.assign` and then reported "already patched" forever — the guard meant to make reinstalling safe was what prevented recovery.

The re-assert that should have repaired it had never run once: both `chartkick:load` handlers were on `document`, but Chartkick dispatches `window.dispatchEvent(new Event("chartkick:load"))`, and a bare `Event` has `bubbles: false`. **`applyChartTheme()` was dead the same way** — an unreported theming bug on the identical root cause.

Fixed by replacing the boolean with an identity check against the wrapper we installed, and moving both listeners to `window`.

## 2. Date ordering — bigger than the race that exposed it

Chart dates were translated correctly and then written in **US order**, because `LocalizedTimeFormatter` substitutes words and never reorders:

| | was | now |
|---|---|---|
| fr | `août 06` | `6 août` |
| de | `Aug. 06` | `6. Aug.` |
| ja | `8月 06` | `8月6日` |
| ru | `авг. 06` | `6 авг.` |

**Ten of eleven locales, wrong on every load** — unlike the race, fully deterministic. English was subtly wrong too (`Aug 06`, not `Aug 6`).

The ordering each locale needs already existed in `red.time.formats`, and `window.RED_I18N.formats` already carried it to the browser. The charts were the one consumer ignoring it.

Two judgment calls: `%b` never `%B`, because ru/uk/pl `months` are genitive (`января` = "of January") and read wrong standing alone on a month axis; and `%H:%M` for all ten non-English locales, each of which already declares 24-hour time itself.

## 3. Hour and minute axes

Chartkick overrides `displayFormats`/`tooltipFormat` with `MMM d, h a` and `h:mm a`, which the adapter's own table never mentions — so neither was in `TOKENS`. A French dashboard drew `Aug 6, 8 PM` (English month **and** English meridian) on the same page whose day axis already read `6 août`. Four `TOKENS` entries also hardcoded `%I:%M %p`, forcing a 12-hour clock on locales that declare `%H`; seven of the ten never translated `meridian` at all.

## 4. Plural selection

`redPluralize` only read `one` and `other`. ru/uk/pl each ship four CLDR categories and their locale files have carried `few` and `many` since the i18n sprint — so JS picked a form the language does not use there, from a dictionary that already held the right one:

```
ru  5 -> 5 секунды    ->  5 секунд    (many)
ru 21 -> 21 секунды   ->  21 секунда  (one)
```

Ported `PrivateBackend::PLURAL_RULES` to the browser, including both traps that table documents: the `%100` guards (11 is `many`, not `one`), and **Polish is not Russian** (pl `one` is exactly 1, so 21 is `many` where ru/uk take `one`).

## Verification

Every fix was confirmed to **fail against the old code** before being kept:

- `expected "UNPATCHED" to include "août"`
- all 11 ordering examples fail against the hardcoded pattern, English included
- `expected "Aug 6, 8 PM" not to include "PM"`

Rendered in a real browser through the full stack:

```
AXIS[en] = "Aug 6"   AXIS[fr] = "6 août"   AXIS[de] = "6. Aug."
AXIS[ru] = "6 авг."  AXIS[ja] = "8月6日"
```

`formatDateTime`'s `.replace('%d', …)` chain became a single regex pass — `%d` matched *inside* `%-d`. That also fixed a latent bug where a repeated directive (`%d/%m/%d`) left the second occurrence as literal text. English output is unchanged character-for-character; `js_date_parity_spec`'s REQ-6 full-year comparison still passes.

New `js_plural_parity_spec` compares the browser against the **real backend** for 11 locales × 13 counts, so correcting the server's rules fails the spec until the JS is corrected too.

**4400 examples, 0 failures. rubocop 551 files, no offenses. bin/i18n-check no failures, 296 warnings — unchanged, so the six new keys × 11 locales clear the parity gate.**

## Notes for review

- The eleven locale patterns are CLDR/ICU-derived, not native-reviewed. Each locale's open review issue (#156–#165) can correct them — they are structural patterns, not prose.
- `chart_date_i18n_spec` previously asserted French equalled `LocalizedTimeFormatter`'s own output for `"%b %d"` — a tautology that restated the implementation and passed just as happily on `août 06`. It now asserts literals across all eleven locales.
- While writing the plural spec: it first ran against **four** locales, not eleven, and still passed. A constant written inside an `RSpec.describe` block is defined at top level, and `spec/system/p7_layout_qa_spec.rb` already defines `LOCALES`. Both are `let` here now, but that collision stays latent for the next spec reaching for the same name.

Leaving #178 open for @gmarziou to verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
