### PR TITLE
ci: pin json < 3 until Rails ships the compatibility fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,14 @@ rails_version = ENV["RAILS_VERSION"] || "~> 8.1.0"
 rails_version = "~> #{rails_version}.0" if rails_version =~ /^\d+\.\d+$/
 gem "rails", rails_version
 
+# json 3.0 (2026-09-07) raises ArgumentError on options that released Rails
+# versions still pass: `quirks_mode` on 7.0-8.0, and a positional options hash
+# in ActiveSupport::JSON.decode on 8.1 (breaks every session/flash read).
+# Fixed on rails main and backported (rails/rails#58601, #58685), but no 8.x
+# release carries it yet and 7.x never will. CI deletes Gemfile.lock, so
+# without this pin every run resolves json 3 and the whole matrix goes red.
+gem "json", "< 3"
+
 gem "puma"
 
 gem "pg"

--- a/bin/full-integration-test
+++ b/bin/full-integration-test
@@ -87,6 +87,9 @@ create_app() {
 
   echo "" >> "$app_dir/Gemfile"
   echo "gem 'rails_error_dashboard', path: '$GEM_DIR'" >> "$app_dir/Gemfile"
+  # Same pin as the gem's Gemfile: released Rails 8.1 cannot decode the
+  # session cookie under json 3.0, so every dashboard page would 500.
+  echo "gem 'json', '< 3'" >> "$app_dir/Gemfile"
 
   log_step "Running bundle install..."
   (cd "$app_dir" && bundle install 2>&1 | tail -3)


### PR DESCRIPTION
## Why

`json` 3.0.0 was published on 2026-09-07 and now raises `ArgumentError` on any option it doesn't recognise. Released Rails versions still pass such options:

- **Rails 7.0–8.0:** ActiveSupport passes `quirks_mode: true` to `JSON.generate`/`JSON.parse`, so any `.to_json` raises `unknown keyword: quirks_mode`.
- **Rails 8.1:** `ActiveSupport::JSON.decode` passes options as a positional hash, so decoding the session cookie raises `wrong number of arguments (given 2, expected 1)` and every request touching session/flash 500s.

CI deletes `Gemfile.lock` before installing, so every run since the release picks up json 3 and the whole matrix fails (see #201, which only touches a locale file). The integration host app is Rails 8.1.3.1 and hits the same bug, so every page returns 500.

Rails fixed this in rails/rails#58601 (2026-08-28) and backported it to 8-0-stable and 8-1-stable, but there is no release with the fix yet, and 7.x will never get it. rails/rails#58685 is the upstream report.

## What

- Pin `gem "json", "< 3"` in the dev `Gemfile`.
- Add the same pin to the host app generated by `bin/full-integration-test`.

The gemspec has no `json` dependency, so this changes nothing for end users. Once Rails 8.0.x/8.1.x ship the backport, the pin can be relaxed for those rows; the Rails 7 rows need it permanently.

## Test plan

- [x] Locally on Rails 8.0.4: bumping json to 3.0.0 makes `spec/requests/coverage_tracking_spec.rb` 500; with the pin the full suite passes (4400 examples, 0 failures).
- [x] Pre-commit chaos suite: 5 apps, 1448 assertions, all passed.
- [ ] Full CI matrix + integration job green here.
- [ ] Update #201 from main and confirm it goes green.

Refs #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Je5ozi8CCwqFow2HfGxfFK
