### PR TITLE
fix: close the 0.11.5 review findings (storm counts, redaction, row lock, async capture, release and baseline analytics)

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ config.enable_breadcrumbs = true
 
 Know your app's runtime state at the moment of failure — GC stats, process memory, thread count, connection pool utilization, Puma thread stats, RubyVM cache health, YJIT compilation stats, and deep runtime insights captured automatically.
 
-- Sub-millisecond total snapshot, every metric individually rescue-wrapped
+- Sub-millisecond for the in-process metrics, every metric individually rescue-wrapped. The one exception is job-queue depth (five `COUNT`s for Solid Queue, a Redis round-trip for Sidekiq): those are queries against your queue store, cached for 10 s per process and switchable off with `config.system_health_queue_stats = false`
 - No ObjectSpace scanning, no Thread backtraces, no subprocess calls
 - RubyVM.stat: constant cache invalidations, shape cache stats
 - YJIT runtime stats: compiled iseqs, invalidation count, code region sizes

--- a/README.md
+++ b/README.md
@@ -476,9 +476,10 @@ Seven analysis engines built in:
 <details>
 <summary><strong>Local Variable + Instance Variable Capture</strong></summary>
 
-See the exact values of local variables and instance variables at the moment an exception was raised — the most valuable debugging context possible.
+See the values of local variables and instance variables at the moment an exception was raised — the most valuable debugging context possible.
 
 - TracePoint(`:raise`) captures locals and ivars before the stack unwinds
+- Strings, arrays and hashes are snapshotted at raise time (one level deep, bounded by the limits below), so an `ensure` block that cleans up state does not overwrite what you see. Other objects are kept by reference and show their state at serialization time
 - Configurable limits: max variable count, nesting depth, string truncation length
 - Sensitive data auto-filtered via Rails `filter_parameters` — passwords, tokens, and PII never stored
 - Never stores Binding objects — values extracted immediately, Binding is GC'd

--- a/_features/baseline-monitoring.md
+++ b/_features/baseline-monitoring.md
@@ -112,10 +112,17 @@ end
 
 ### How Baselines are Calculated
 
-The `BaselineCalculator` service runs daily via background job:
+The gem does **not** schedule the calculation itself. Run `BaselineCalculationJob`
+from your own scheduler, roughly once a day; until it has run there are no
+baselines and no baseline alerts.
 
 ```ruby
-# Triggered automatically
+# Solid Queue — config/recurring.yml
+# baseline_calculation:
+#   class: RailsErrorDashboard::BaselineCalculationJob
+#   schedule: every day at 3am
+
+# sidekiq-cron / whenever / cron
 RailsErrorDashboard::BaselineCalculationJob.perform_later
 
 # Or manually via console
@@ -124,11 +131,20 @@ RailsErrorDashboard::Services::BaselineCalculator.calculate_all_baselines
 
 **Process**:
 1. For each unique (error_type, platform) pair:
-2. Fetch error counts for lookback period
-3. Group by time unit (hour/day/week)
-4. Calculate statistics (mean, std_dev, percentiles)
+2. Count occurrences (individual captured events, not error groups) over the lookback period
+3. Bucket them into calendar hours / days / weeks, including buckets with zero events
+4. Calculate statistics (mean, std_dev, percentiles) over those buckets
 5. Store in `error_baselines` table
 6. Update existing baselines or create new ones
+
+**Units**: an hourly baseline is a distribution of per-hour event counts over
+the last four weeks (672 samples), a daily baseline is per-day counts over
+twelve weeks (84 samples), a weekly baseline is per-week counts over a year
+(52 samples). The anomaly check compares the current hour, today, and this
+week against the matching baseline.
+
+Bucketing goes through [groupdate](https://github.com/ankane/groupdate), so
+the same calculation runs on SQLite, PostgreSQL and MySQL.
 
 **Performance**: Full recalculation takes ~5-10 minutes for 10,000 errors.
 
@@ -552,8 +568,9 @@ config.baseline_alert_severities = [:critical, :high, :elevated]
 
 3. **Recalculate baselines**:
 ```ruby
-# Force recalculation
-RailsErrorDashboard::Services::BaselineCalculator.calculate_all_baselines(force: true)
+RailsErrorDashboard::BaselineCalculationJob.perform_now
+# or, without the job wrapper
+RailsErrorDashboard::Services::BaselineCalculator.calculate_all_baselines
 ```
 
 4. **Monitor trends manually**:

--- a/_features/baseline-monitoring.md
+++ b/_features/baseline-monitoring.md
@@ -143,6 +143,12 @@ twelve weeks (84 samples), a weekly baseline is per-week counts over a year
 (52 samples). The anomaly check compares the current hour, today, and this
 week against the matching baseline.
 
+**Scope**: baselines are keyed by error type and platform and pooled across
+all applications. The current-period count that is compared against them is
+scoped to the application being viewed (or the application an error belongs
+to), so one application's spike is not reported on another's dashboard. The
+baseline itself is not application-specific yet.
+
 Bucketing goes through [groupdate](https://github.com/ankane/groupdate), so
 the same calculation runs on SQLite, PostgreSQL and MySQL.
 

--- a/_guides/configuration.md
+++ b/_guides/configuration.md
@@ -197,6 +197,8 @@ recycled Puma thread would render in whatever language the host app last used.
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `enable_system_health` | Boolean | `false` | Capture GC, memory, threads, connection pool, RubyVM cache, YJIT stats at error time |
+| `system_health_queue_stats` | Boolean | `true` | Include job-queue depth counts (Sidekiq/Solid Queue/GoodJob) in the snapshot. These are queries against the queue store, not in-process reads |
+| `system_health_queue_stats_cache_seconds` | Integer | `10` | Reuse the queue counts for this long per process, so an error burst runs them once per interval. `0` runs them on every error |
 
 ### Local Variable Capture (v0.4.0)
 

--- a/_reference/migration-strategy.md
+++ b/_reference/migration-strategy.md
@@ -702,6 +702,29 @@ fingerprint, are unaffected. No data migration is provided because the old
 hash was derived from the full message and a first application frame that is
 not stored in a form the migration could recompute reliably.
 
+### Behaviour change: string metadata is fitted to its columns
+
+Before 0.11.6 an over-long string value (a 300-character `app_version`, say)
+made the insert fail on MySQL in strict mode, the capture path rescued the
+failure, and the error was silently lost. String-typed columns are now
+truncated to their column limit before writing, on every adapter, using the
+Rails default of 255 characters where the adapter declares no limit.
+
+Consequence: on PostgreSQL and SQLite, which previously stored such values in
+full, `app_version`, `git_sha`, `error_type`, `controller_name`,
+`action_name` and the other string columns are now capped at 255 characters.
+Two release identifiers that differ only after their first 255 characters
+become indistinguishable on the Releases page. Error grouping is unaffected:
+the fingerprint is computed from the raw values before truncation.
+
+### Baseline scoping
+
+The current-period count in a baseline anomaly check is now scoped to the
+application being viewed, so one application's spike no longer shows as an
+anomaly on another application's dashboard. The baselines themselves are
+still calculated per error type and platform across all applications;
+fully application-specific baselines are follow-up work.
+
 ---
 
 ## Conclusion

--- a/_reference/migration-strategy.md
+++ b/_reference/migration-strategy.md
@@ -667,6 +667,43 @@ config.enable_crash_capture = true
 
 ---
 
+## Upgrading to v0.11.6
+
+v0.11.6 adds one migration and changes how one class of error is grouped.
+
+### Migration: release attribution on occurrences
+
+`add_release_to_error_occurrences` adds `app_version` and `git_sha` to
+`rails_error_dashboard_error_occurrences` and backfills existing rows from
+their group. The Releases page counts occurrences per release from now on.
+
+```bash
+bundle update rails_error_dashboard
+rails rails_error_dashboard:install:migrations
+rails db:migrate
+```
+
+Separate database: move `*_add_release_to_error_occurrences.rb` to
+`db/error_dashboard_migrate/` before migrating, as in the sections above.
+
+### Behaviour change: fingerprints for messages longer than 500 characters
+
+The error fingerprint now hashes only the first 500 characters of the raw
+message, on both the normal capture path and the storm-protection path. Before
+0.11.6 the normal path hashed the whole message while storm reconciliation
+hashed a 500-character exemplar, so a long-message error changed identity
+whenever the circuit breaker changed state and its counts landed on two rows.
+
+Consequence on upgrade: an error whose message runs past 500 characters gets a
+**new group** on its next occurrence. The pre-0.11.6 group is not reopened or
+merged; it keeps its status and history and simply stops receiving counts.
+Errors with messages of 500 characters or fewer, and errors using a custom
+fingerprint, are unaffected. No data migration is provided because the old
+hash was derived from the full message and a first application frame that is
+not stored in a form the migration could recompute reliably.
+
+---
+
 ## Conclusion
 
 The hybrid squashed + incremental strategy provides the best of both worlds:

--- a/app/jobs/rails_error_dashboard/async_error_logging_job.rb
+++ b/app/jobs/rails_error_dashboard/async_error_logging_job.rb
@@ -37,8 +37,16 @@ module RailsErrorDashboard
     # Reconstruct exception from serialized data
     # @param data [Hash] Serialized exception data
     # @return [Exception] Reconstructed exception object
+    #
+    # Never relies on the subclass constructor: many real exception classes
+    # take something other than a message (ActiveRecord::RecordInvalid wants
+    # the record, custom errors take keywords), and `Klass.new(message)` on
+    # those raised inside the job, which rescued it and dropped the capture.
+    # Allocate the right class so error_type/fingerprint stay correct, then
+    # set the message with Exception's own initializer, bypassing whatever
+    # the subclass expects. Fall back to the constructor for classes whose
+    # `message` needs state their initializer sets.
     def reconstruct_exception(data)
-      # Get or create the exception class
       exception_class = begin
         data[:class_name].constantize
       rescue NameError
@@ -46,13 +54,33 @@ module RailsErrorDashboard
         StandardError
       end
 
-      # Create new exception with the original message
-      exception = exception_class.new(data[:message])
+      exception = allocate_exception(exception_class, data[:message]) ||
+                  construct_exception(exception_class, data[:message]) ||
+                  StandardError.new(data[:message])
 
       # Restore the backtrace
       exception.set_backtrace(data[:backtrace]) if data[:backtrace]
 
       exception
+    end
+
+    def allocate_exception(exception_class, message)
+      return nil unless exception_class < Exception
+
+      exception = exception_class.allocate
+      Exception.instance_method(:initialize).bind_call(exception, message)
+      exception.message # a subclass `message` that needs constructor state raises here
+      exception
+    rescue StandardError, NoMemoryError
+      nil
+    end
+
+    def construct_exception(exception_class, message)
+      exception = exception_class.new(message)
+      exception.message
+      exception
+    rescue StandardError
+      nil
     end
   end
 end

--- a/app/jobs/rails_error_dashboard/baseline_calculation_job.rb
+++ b/app/jobs/rails_error_dashboard/baseline_calculation_job.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module RailsErrorDashboard
+  # Recalculates every error-type/platform baseline from recent history.
+  #
+  # Nothing in the gem schedules this: run it from the host's scheduler
+  # (Solid Queue recurring tasks, sidekiq-cron, whenever, cron + runner)
+  # roughly daily. Without it there are no baselines and no baseline alerts.
+  class BaselineCalculationJob < ApplicationJob
+    queue_as :default
+
+    def perform
+      result = Services::BaselineCalculator.calculate_all_baselines
+      Rails.logger.info("[RailsErrorDashboard] Baselines recalculated: #{result[:calculated]}")
+      result
+    rescue => e
+      Rails.logger.error("[RailsErrorDashboard] BaselineCalculationJob failed: #{e.class}: #{e.message}")
+      raise
+    end
+  end
+end

--- a/app/models/rails_error_dashboard/error_log.rb
+++ b/app/models/rails_error_dashboard/error_log.rb
@@ -339,13 +339,9 @@ module RailsErrorDashboard
       return { anomaly: false, message: "Feature disabled" } unless RailsErrorDashboard.configuration.enable_baseline_alerts
       return { anomaly: false, message: "No baseline available" } unless defined?(Queries::BaselineStats)
 
-      # Get count of this error type today
-      today_count = ErrorLog.where(
-        error_type: error_type,
-        platform: platform
-      ).where("occurred_at >= ?", Time.current.beginning_of_day).count
-
-      Queries::BaselineStats.new(error_type, platform).check_anomaly(today_count, sensitivity: sensitivity)
+      # Current hour / day / week counted in the baselines' own units — a
+      # day's count against an hourly baseline flagged everything.
+      Queries::BaselineStats.new(error_type, platform).check_current_anomaly(sensitivity: sensitivity)
     end
 
     # Detect cyclical occurrence patterns (daily/weekly rhythms)

--- a/app/models/rails_error_dashboard/error_log.rb
+++ b/app/models/rails_error_dashboard/error_log.rb
@@ -341,7 +341,8 @@ module RailsErrorDashboard
 
       # Current hour / day / week counted in the baselines' own units — a
       # day's count against an hourly baseline flagged everything.
-      Queries::BaselineStats.new(error_type, platform).check_current_anomaly(sensitivity: sensitivity)
+      Queries::BaselineStats.new(error_type, platform)
+                            .check_current_anomaly(sensitivity: sensitivity, application_id: application_id)
     end
 
     # Detect cyclical occurrence patterns (daily/weekly rhythms)

--- a/app/models/rails_error_dashboard/error_logs_record.rb
+++ b/app/models/rails_error_dashboard/error_logs_record.rb
@@ -34,5 +34,39 @@ module RailsErrorDashboard
     # Database connection will be configured by the engine initializer
     # after the user's configuration is loaded
     # See lib/rails_error_dashboard/engine.rb
+
+    # Rails' default for a string column when the adapter has one (MySQL).
+    DEFAULT_STRING_LIMIT = 255
+
+    # Truncate string-typed attributes to their column limits. MySQL in strict
+    # mode rejects an over-long value outright, the capture path rescues the
+    # failure, and the error is silently lost — over a 300-character app
+    # version. Columns without a declared limit are clamped to the Rails
+    # default so behaviour is the same on every adapter. Text columns are
+    # untouched. Identity (error_hash) is computed from the raw values before
+    # this runs, so clamping display metadata never changes grouping.
+    # @param attributes [Hash] attribute name => value
+    # @return [Hash] a copy with over-long strings truncated
+    def self.clamp_string_attributes(attributes)
+      limits = string_column_limits
+      attributes.each_with_object({}) do |(name, value), clamped|
+        limit = limits[name.to_s]
+        clamped[name] = if limit && value.is_a?(String) && value.length > limit
+          value[0, limit]
+        else
+          value
+        end
+      end
+    rescue => e
+      RailsErrorDashboard::Logger.debug("[RailsErrorDashboard] clamp_string_attributes failed: #{e.message}")
+      attributes
+    end
+
+    # @return [Hash] column name => character limit, string columns only (memoized per class)
+    def self.string_column_limits
+      @string_column_limits ||= columns_hash.each_with_object({}) do |(name, column), limits|
+        limits[name] = column.limit || DEFAULT_STRING_LIMIT if column.type == :string
+      end
+    end
   end
 end

--- a/db/migrate/20260908000001_add_release_to_error_occurrences.rb
+++ b/db/migrate/20260908000001_add_release_to_error_occurrences.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Release attribution belongs on the occurrence, not the group.
+#
+# An ErrorLog row is a GROUP: it keeps the app_version/git_sha of the first
+# capture in its window and recurrences do not touch them. So an error first
+# seen in v1 that kept firing after the v2 deploy was reported entirely under
+# v1, and the release timeline could not answer "did this deploy make things
+# worse". Each ErrorOccurrence now records the release it happened under, and
+# ReleaseTimeline counts occurrences per release.
+#
+# Existing occurrences are backfilled from their group's release. That is the
+# same attribution the dashboard showed before this migration (no worse), and
+# it keeps historical releases populated instead of dropping to zero.
+class AddReleaseToErrorOccurrences < ActiveRecord::Migration[7.0]
+  def up
+    return if column_exists?(:rails_error_dashboard_error_occurrences, :app_version)
+
+    add_column :rails_error_dashboard_error_occurrences, :app_version, :string
+    add_column :rails_error_dashboard_error_occurrences, :git_sha, :string
+    add_index :rails_error_dashboard_error_occurrences, [ :app_version, :occurred_at ],
+              name: "index_error_occurrences_on_version_and_time"
+
+    # Correlated subqueries rather than UPDATE ... FROM / JOIN: the one form
+    # SQLite, PostgreSQL and MySQL all accept.
+    execute <<~SQL.squish
+      UPDATE rails_error_dashboard_error_occurrences
+      SET app_version = (
+            SELECT app_version FROM rails_error_dashboard_error_logs
+            WHERE rails_error_dashboard_error_logs.id = rails_error_dashboard_error_occurrences.error_log_id
+          ),
+          git_sha = (
+            SELECT git_sha FROM rails_error_dashboard_error_logs
+            WHERE rails_error_dashboard_error_logs.id = rails_error_dashboard_error_occurrences.error_log_id
+          )
+      WHERE app_version IS NULL
+    SQL
+  end
+
+  def down
+    remove_index :rails_error_dashboard_error_occurrences, name: "index_error_occurrences_on_version_and_time"
+    remove_column :rails_error_dashboard_error_occurrences, :git_sha
+    remove_column :rails_error_dashboard_error_occurrences, :app_version
+  end
+end

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -667,14 +667,14 @@ end
 
 System health snapshots are designed with host app safety as the top priority:
 
-- **Sub-millisecond** — Total snapshot completes in < 1ms
+- **Sub-millisecond in-process metrics** — GC, memory, threads, pool, VM stats complete in < 1ms. Job-queue depth counts are the documented exception: they query the queue store, so they are cached per process (`system_health_queue_stats_cache_seconds`, default 10) and can be disabled (`system_health_queue_stats = false`)
 - **Every metric individually wrapped** in `rescue => nil` — one failure doesn't affect others
 - **Top-level rescue** — If everything fails, returns `{ captured_at: ... }` (never raises)
 - **No ObjectSpace** — Never calls `ObjectSpace.each_object` or `ObjectSpace.count_objects` (heap scan)
 - **No Thread backtraces** — Only `Thread.list.count` (O(1)), never `.map(&:backtrace)` (GVL hold)
 - **No subprocess** — Process memory uses Linux procfs only, no `ps`, no fork, no backtick
 - **No new gems** — Uses only Ruby stdlib (`Etc`) and ActiveRecord
-- **No global state** — No Thread.current, no mutex, no memoization
+- **No global state** — No Thread.current, no mutex; the only memoization is the lock-free per-process cache of the queue-depth counts
 
 ### Async Logging Compatibility
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -731,7 +731,7 @@ This page helps identify errors associated with connection pool exhaustion or da
 
 ## Local Variable Capture (v0.4.0)
 
-**⚙️ Optional Feature** - Local variable capture is disabled by default. Enable it to see the exact values of local variables at the moment an exception was raised:
+**⚙️ Optional Feature** - Local variable capture is disabled by default. Enable it to see the values of local variables at the moment an exception was raised (strings, arrays and hashes are snapshotted one level deep at raise time; other objects are kept by reference):
 
 ```ruby
 config.enable_local_variables = true

--- a/docs/MIGRATION_STRATEGY.md
+++ b/docs/MIGRATION_STRATEGY.md
@@ -702,6 +702,29 @@ fingerprint, are unaffected. No data migration is provided because the old
 hash was derived from the full message and a first application frame that is
 not stored in a form the migration could recompute reliably.
 
+### Behaviour change: string metadata is fitted to its columns
+
+Before 0.11.6 an over-long string value (a 300-character `app_version`, say)
+made the insert fail on MySQL in strict mode, the capture path rescued the
+failure, and the error was silently lost. String-typed columns are now
+truncated to their column limit before writing, on every adapter, using the
+Rails default of 255 characters where the adapter declares no limit.
+
+Consequence: on PostgreSQL and SQLite, which previously stored such values in
+full, `app_version`, `git_sha`, `error_type`, `controller_name`,
+`action_name` and the other string columns are now capped at 255 characters.
+Two release identifiers that differ only after their first 255 characters
+become indistinguishable on the Releases page. Error grouping is unaffected:
+the fingerprint is computed from the raw values before truncation.
+
+### Baseline scoping
+
+The current-period count in a baseline anomaly check is now scoped to the
+application being viewed, so one application's spike no longer shows as an
+anomaly on another application's dashboard. The baselines themselves are
+still calculated per error type and platform across all applications;
+fully application-specific baselines are follow-up work.
+
 ---
 
 ## Conclusion

--- a/docs/MIGRATION_STRATEGY.md
+++ b/docs/MIGRATION_STRATEGY.md
@@ -667,6 +667,43 @@ config.enable_crash_capture = true
 
 ---
 
+## Upgrading to v0.11.6
+
+v0.11.6 adds one migration and changes how one class of error is grouped.
+
+### Migration: release attribution on occurrences
+
+`add_release_to_error_occurrences` adds `app_version` and `git_sha` to
+`rails_error_dashboard_error_occurrences` and backfills existing rows from
+their group. The Releases page counts occurrences per release from now on.
+
+```bash
+bundle update rails_error_dashboard
+rails rails_error_dashboard:install:migrations
+rails db:migrate
+```
+
+Separate database: move `*_add_release_to_error_occurrences.rb` to
+`db/error_dashboard_migrate/` before migrating, as in the sections above.
+
+### Behaviour change: fingerprints for messages longer than 500 characters
+
+The error fingerprint now hashes only the first 500 characters of the raw
+message, on both the normal capture path and the storm-protection path. Before
+0.11.6 the normal path hashed the whole message while storm reconciliation
+hashed a 500-character exemplar, so a long-message error changed identity
+whenever the circuit breaker changed state and its counts landed on two rows.
+
+Consequence on upgrade: an error whose message runs past 500 characters gets a
+**new group** on its next occurrence. The pre-0.11.6 group is not reopened or
+merged; it keeps its status and history and simply stops receiving counts.
+Errors with messages of 500 characters or fewer, and errors using a custom
+fingerprint, are unaffected. No data migration is provided because the old
+hash was derived from the full message and a first application frame that is
+not stored in a form the migration could recompute reliably.
+
+---
+
 ## Conclusion
 
 The hybrid squashed + incremental strategy provides the best of both worlds:

--- a/docs/features/BASELINE_MONITORING.md
+++ b/docs/features/BASELINE_MONITORING.md
@@ -112,10 +112,17 @@ end
 
 ### How Baselines are Calculated
 
-The `BaselineCalculator` service runs daily via background job:
+The gem does **not** schedule the calculation itself. Run `BaselineCalculationJob`
+from your own scheduler, roughly once a day; until it has run there are no
+baselines and no baseline alerts.
 
 ```ruby
-# Triggered automatically
+# Solid Queue — config/recurring.yml
+# baseline_calculation:
+#   class: RailsErrorDashboard::BaselineCalculationJob
+#   schedule: every day at 3am
+
+# sidekiq-cron / whenever / cron
 RailsErrorDashboard::BaselineCalculationJob.perform_later
 
 # Or manually via console
@@ -124,11 +131,20 @@ RailsErrorDashboard::Services::BaselineCalculator.calculate_all_baselines
 
 **Process**:
 1. For each unique (error_type, platform) pair:
-2. Fetch error counts for lookback period
-3. Group by time unit (hour/day/week)
-4. Calculate statistics (mean, std_dev, percentiles)
+2. Count occurrences (individual captured events, not error groups) over the lookback period
+3. Bucket them into calendar hours / days / weeks, including buckets with zero events
+4. Calculate statistics (mean, std_dev, percentiles) over those buckets
 5. Store in `error_baselines` table
 6. Update existing baselines or create new ones
+
+**Units**: an hourly baseline is a distribution of per-hour event counts over
+the last four weeks (672 samples), a daily baseline is per-day counts over
+twelve weeks (84 samples), a weekly baseline is per-week counts over a year
+(52 samples). The anomaly check compares the current hour, today, and this
+week against the matching baseline.
+
+Bucketing goes through [groupdate](https://github.com/ankane/groupdate), so
+the same calculation runs on SQLite, PostgreSQL and MySQL.
 
 **Performance**: Full recalculation takes ~5-10 minutes for 10,000 errors.
 
@@ -552,8 +568,9 @@ config.baseline_alert_severities = [:critical, :high, :elevated]
 
 3. **Recalculate baselines**:
 ```ruby
-# Force recalculation
-RailsErrorDashboard::Services::BaselineCalculator.calculate_all_baselines(force: true)
+RailsErrorDashboard::BaselineCalculationJob.perform_now
+# or, without the job wrapper
+RailsErrorDashboard::Services::BaselineCalculator.calculate_all_baselines
 ```
 
 4. **Monitor trends manually**:

--- a/docs/features/BASELINE_MONITORING.md
+++ b/docs/features/BASELINE_MONITORING.md
@@ -143,6 +143,12 @@ twelve weeks (84 samples), a weekly baseline is per-week counts over a year
 (52 samples). The anomaly check compares the current hour, today, and this
 week against the matching baseline.
 
+**Scope**: baselines are keyed by error type and platform and pooled across
+all applications. The current-period count that is compared against them is
+scoped to the application being viewed (or the application an error belongs
+to), so one application's spike is not reported on another's dashboard. The
+baseline itself is not application-specific yet.
+
 Bucketing goes through [groupdate](https://github.com/ankane/groupdate), so
 the same calculation runs on SQLite, PostgreSQL and MySQL.
 

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -197,6 +197,8 @@ recycled Puma thread would render in whatever language the host app last used.
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `enable_system_health` | Boolean | `false` | Capture GC, memory, threads, connection pool, RubyVM cache, YJIT stats at error time |
+| `system_health_queue_stats` | Boolean | `true` | Include job-queue depth counts (Sidekiq/Solid Queue/GoodJob) in the snapshot. These are queries against the queue store, not in-process reads |
+| `system_health_queue_stats_cache_seconds` | Integer | `10` | Reuse the queue counts for this long per process, so an error burst runs them once per interval. `0` runs them on every error |
 
 ### Local Variable Capture (v0.4.0)
 

--- a/lib/rails_error_dashboard/commands/find_or_increment_error.rb
+++ b/lib/rails_error_dashboard/commands/find_or_increment_error.rb
@@ -4,6 +4,10 @@ module RailsErrorDashboard
   module Commands
     # Command: Find an existing error by hash or create a new one
     # Uses pessimistic locking to prevent race conditions in multi-app scenarios.
+    # The whole find-and-write runs inside ONE transaction: a row lock taken
+    # by SELECT ... FOR UPDATE lives only as long as the transaction that took
+    # it, so a lock on a standalone SELECT was released before the UPDATE ran
+    # and two concurrent captures could both read count N and both write N+1.
     #
     # Search order:
     # 1. Unresolved errors with same hash within 24 hours → increment occurrence count
@@ -37,16 +41,18 @@ module RailsErrorDashboard
       end
 
       def call
-        # Priority 1: Find unresolved match (existing behavior)
-        existing = find_unresolved
-        return increment_existing(existing) if existing
+        ErrorLog.transaction do
+          # Priority 1: Find unresolved match (existing behavior)
+          existing = find_unresolved
+          next increment_existing(existing) if existing
 
-        # Priority 2: Find resolved/wont_fix match → reopen
-        resolved = find_resolved
-        return reopen_existing(resolved) if resolved
+          # Priority 2: Find resolved/wont_fix match → reopen
+          resolved = find_resolved
+          next reopen_existing(resolved) if resolved
 
-        # Priority 3: Create new record
-        create_new_or_retry
+          # Priority 3: Create new record
+          create_new_or_retry
+        end
       end
 
       private
@@ -132,7 +138,12 @@ module RailsErrorDashboard
       end
 
       def create_new_or_retry
-        ErrorLog.create!(@attributes.reverse_merge(resolved: false))
+        # Savepoint: on PostgreSQL a unique-violation poisons the enclosing
+        # transaction, and the retry lookups below would fail with "current
+        # transaction is aborted" instead of finding the winner's row.
+        ErrorLog.transaction(requires_new: true) do
+          ErrorLog.create!(@attributes.reverse_merge(resolved: false))
+        end
       rescue ActiveRecord::RecordNotUnique
         # Race condition: another process created the same error
         retry_existing = with_environment(

--- a/lib/rails_error_dashboard/commands/flush_storm_counts.rb
+++ b/lib/rails_error_dashboard/commands/flush_storm_counts.rb
@@ -138,7 +138,7 @@ module RailsErrorDashboard
           error_hash: error_hash,
           resolved: false
         }.compact
-        ErrorLog.create!(**Services::SensitiveDataFilter.filter_attributes(create_attrs))
+        ErrorLog.create!(**ErrorLog.clamp_string_attributes(Services::SensitiveDataFilter.filter_attributes(create_attrs)))
         count
       end
 

--- a/lib/rails_error_dashboard/commands/flush_storm_counts.rb
+++ b/lib/rails_error_dashboard/commands/flush_storm_counts.rb
@@ -8,7 +8,8 @@ module RailsErrorDashboard
     # Runs in a background job (DB allowed). For each counted fingerprint:
     #   1. Recompute the canonical error_hash from the stored identity parts
     #      (the gate's key deliberately omits application_id — resolved here)
-    #   2. Unresolved match  → single UPDATE: occurrence_count += N
+    #   2. Unresolved match  → the ONE row FindOrIncrementError would pick
+    #      (24 h window, exact environment first): occurrence_count += N
     #   3. Resolved match    → reopen (mirrors FindOrIncrementError semantics)
     #   4. No match          → create a minimal ErrorLog from the exemplar
     #
@@ -61,24 +62,29 @@ module RailsErrorDashboard
         last_seen = parse_time(entry["last_seen_at"]) || Time.current
         env = current_environment
 
-        # Priority 1: unresolved match — one UPDATE, no row instantiation.
-        # Environment mirrors FindOrIncrementError: exact row first, then a
-        # legacy NULL row which is stamped as it is claimed. Two statements
-        # rather than one IN (env, NULL), because update_all would hit BOTH
-        # rows when they coexist and double-count.
-        unresolved = ErrorLog.unresolved.where(error_hash: error_hash, application_id: application.id)
-        if env
-          updated = unresolved.where(environment: env)
-            .update_all([ "occurrence_count = occurrence_count + ?, last_seen_at = ?", count, last_seen ])
-          return count if updated.positive?
-
-          updated = unresolved.where(environment: nil)
-            .update_all([ "occurrence_count = occurrence_count + ?, last_seen_at = ?, environment = ?",
-                          count, last_seen, env ])
-          return count if updated.positive?
-        else
-          updated = unresolved.update_all([ "occurrence_count = occurrence_count + ?, last_seen_at = ?", count, last_seen ])
-          return count if updated.positive?
+        # Priority 1: unresolved match — ONE row, chosen exactly as
+        # FindOrIncrementError chooses it (same hash + application, occurred
+        # within 24 h, exact environment before a legacy NULL row, most
+        # recently seen first), then a single atomic UPDATE on that id.
+        #
+        # It must be one row: the normal path opens a fresh group once the
+        # previous one's occurred_at falls outside the 24 h window, so a
+        # long-running unresolved error legitimately owns several unresolved
+        # rows. An update_all across the whole hash would add N to every one
+        # of them — seven real events becoming twelve counted occurrences.
+        target = unresolved_target(error_hash, application, env)
+        if target
+          if env && target.environment.blank?
+            ErrorLog.where(id: target.id).update_all([
+              "occurrence_count = occurrence_count + ?, last_seen_at = ?, environment = ?",
+              count, last_seen, env
+            ])
+          else
+            ErrorLog.where(id: target.id).update_all([
+              "occurrence_count = occurrence_count + ?, last_seen_at = ?", count, last_seen
+            ])
+          end
+          return count
         end
 
         # Priority 2: resolved/wont_fix match — reopen, mirroring
@@ -135,6 +141,18 @@ module RailsErrorDashboard
       end
 
 
+      # The unresolved row the full capture path would increment right now.
+      def unresolved_target(error_hash, application, env)
+        scope = ErrorLog.unresolved
+          .where(error_hash: error_hash, application_id: application.id)
+          .where("occurred_at >= ?", 24.hours.ago)
+        if env
+          scope = scope.where(environment: [ env, nil ])
+            .order(Arel.sql("CASE WHEN environment IS NULL THEN 1 ELSE 0 END"))
+        end
+        scope.order(last_seen_at: :desc).select(:id, :environment).first
+      end
+
       # The redaction LogError applies to a message, for exemplars that reach
       # the database by any other route (first-seen rows, the storm ledger).
       def redact_message(message)
@@ -142,7 +160,6 @@ module RailsErrorDashboard
 
         Services::SensitiveDataFilter.filter_attributes({ message: message.to_s })[:message]
       end
-
 
       # Mirrors ErrorHashGenerator.call exactly: same fields, same order,
       # same normalization — so counts land on the same ErrorLog the full

--- a/lib/rails_error_dashboard/commands/flush_storm_counts.rb
+++ b/lib/rails_error_dashboard/commands/flush_storm_counts.rb
@@ -107,12 +107,17 @@ module RailsErrorDashboard
 
         # Priority 3: first seen during count-only mode — minimal ErrorLog
         # from the exemplar (no backtrace/context was captured; the next
-        # occurrence after the storm fills in detail via the normal path)
+        # occurrence after the storm fills in detail via the normal path).
+        #
+        # The exemplar message is RAW — the gate stores what the exception
+        # said so the canonical hash (computed above, from the raw message,
+        # exactly as the full path does) still lands on the same row. It must
+        # therefore go through the same redaction as LogError before it is
+        # persisted; storm protection and sensitive filtering are both on by
+        # default, and an incident is exactly when a password in a message
+        # must not reach the database.
         create_attrs = {
-          environment: env
-        }.compact
-        ErrorLog.create!(
-          **create_attrs,
+          environment: env,
           application_id: application.id,
           error_type: entry["error_class"],
           message: entry["message"],
@@ -124,9 +129,20 @@ module RailsErrorDashboard
           occurrence_count: count,
           error_hash: error_hash,
           resolved: false
-        )
+        }.compact
+        ErrorLog.create!(**Services::SensitiveDataFilter.filter_attributes(create_attrs))
         count
       end
+
+
+      # The redaction LogError applies to a message, for exemplars that reach
+      # the database by any other route (first-seen rows, the storm ledger).
+      def redact_message(message)
+        return message if message.blank?
+
+        Services::SensitiveDataFilter.filter_attributes({ message: message.to_s })[:message]
+      end
+
 
       # Mirrors ErrorHashGenerator.call exactly: same fields, same order,
       # same normalization — so counts land on the same ErrorLog the full
@@ -196,7 +212,7 @@ module RailsErrorDashboard
         existing = event.top_fingerprints_list
         fresh = @entries.map { |e|
           e = e.with_indifferent_access if e.respond_to?(:with_indifferent_access)
-          { "class" => e["error_class"], "message" => e["message"].to_s[0, 120], "count" => e["count"].to_i }
+          { "class" => e["error_class"], "message" => redact_message(e["message"]).to_s[0, 120], "count" => e["count"].to_i }
         }
 
         merged = (existing + fresh)

--- a/lib/rails_error_dashboard/commands/flush_storm_counts.rb
+++ b/lib/rails_error_dashboard/commands/flush_storm_counts.rb
@@ -60,7 +60,9 @@ module RailsErrorDashboard
 
         error_hash = canonical_hash(entry, application)
         last_seen = parse_time(entry["last_seen_at"]) || Time.current
-        env = current_environment
+        # An explicit environment captured at the gate wins over the worker's
+        # own, mirroring LogError#resolve_environment for full captures.
+        env = current_environment && (entry["environment"].presence || current_environment)
 
         # Priority 1: unresolved match — ONE row, chosen exactly as
         # FindOrIncrementError chooses it (same hash + application, occurred

--- a/lib/rails_error_dashboard/commands/log_error.rb
+++ b/lib/rails_error_dashboard/commands/log_error.rb
@@ -299,6 +299,9 @@ module RailsErrorDashboard
         # Apply sensitive data filtering (on by default)
         attributes = Services::SensitiveDataFilter.filter_attributes(attributes)
 
+        # Fit string metadata to its columns (after hashing, before writing)
+        attributes = ErrorLog.clamp_string_attributes(attributes)
+
         # Harvest breadcrumbs (if enabled and column exists)
         if !storm_lite && ErrorLog.column_names.include?("breadcrumbs") && RailsErrorDashboard.configuration.enable_breadcrumbs
           # Sync path: harvest from current thread
@@ -389,7 +392,7 @@ module RailsErrorDashboard
             occurrence_columns = ErrorOccurrence.column_names
             occurrence_attrs[:app_version] = attributes[:app_version] if occurrence_columns.include?("app_version")
             occurrence_attrs[:git_sha] = attributes[:git_sha] if occurrence_columns.include?("git_sha")
-            ErrorOccurrence.create(occurrence_attrs)
+            ErrorOccurrence.create(ErrorOccurrence.clamp_string_attributes(occurrence_attrs))
           rescue => e
             RailsErrorDashboard::Logger.error("Failed to create error occurrence: #{e.message}")
           end

--- a/lib/rails_error_dashboard/commands/log_error.rb
+++ b/lib/rails_error_dashboard/commands/log_error.rb
@@ -377,13 +377,19 @@ module RailsErrorDashboard
         #  Track individual error occurrence for co-occurrence analysis (if table exists)
         if defined?(ErrorOccurrence) && ErrorOccurrence.table_exists?
           begin
-            ErrorOccurrence.create(
+            occurrence_attrs = {
               error_log: error_log,
               occurred_at: attributes[:occurred_at],
               user_id: attributes[:user_id],
               request_id: error_context.request_id,
               session_id: error_context.session_id
-            )
+            }
+            # The release THIS event happened under. The group keeps its first
+            # release; per-release counts come from here (ReleaseTimeline).
+            occurrence_columns = ErrorOccurrence.column_names
+            occurrence_attrs[:app_version] = attributes[:app_version] if occurrence_columns.include?("app_version")
+            occurrence_attrs[:git_sha] = attributes[:git_sha] if occurrence_columns.include?("git_sha")
+            ErrorOccurrence.create(occurrence_attrs)
           rescue => e
             RailsErrorDashboard::Logger.error("Failed to create error occurrence: #{e.message}")
           end

--- a/lib/rails_error_dashboard/configuration.rb
+++ b/lib/rails_error_dashboard/configuration.rb
@@ -169,6 +169,8 @@ module RailsErrorDashboard
 
     # System health snapshot (GC, memory, threads, connection pool at error time)
     attr_accessor :enable_system_health            # Master switch (default: false)
+    attr_accessor :system_health_queue_stats       # Include job-queue depth counts (default: true)
+    attr_accessor :system_health_queue_stats_cache_seconds # Reuse queue counts this long per process (default: 10)
 
     # Local variable capture via TracePoint(:raise)
     attr_accessor :enable_local_variables            # Master switch (default: false)
@@ -393,6 +395,11 @@ module RailsErrorDashboard
 
       # System health snapshot defaults - OFF by default (opt-in)
       @enable_system_health = false  # Capture GC, memory, threads, connection pool at error time
+      # Queue-depth counts are queries against the queue store (five COUNTs
+      # for Solid Queue), the one part of the snapshot that is not sub-ms.
+      # Cached per process so an error burst runs them once per interval.
+      @system_health_queue_stats = true
+      @system_health_queue_stats_cache_seconds = 10
 
       # Local variable capture defaults - OFF by default (opt-in)
       @enable_local_variables = false           # TracePoint(:raise) for local var capture

--- a/lib/rails_error_dashboard/queries/analytics_stats.rb
+++ b/lib/rails_error_dashboard/queries/analytics_stats.rb
@@ -126,7 +126,10 @@ module RailsErrorDashboard
         total = error_statistics[:total]
         return 0 if total.zero?
 
-        resolved_count = ErrorLog.resolved.where("occurred_at >= ?", @start_date).count
+        # Same scoped relation as the denominator: an unscoped numerator
+        # counted every application's resolved errors against one
+        # application's total, and the "rate" went past 100%.
+        resolved_count = base_query.resolved.count
         ((resolved_count.to_f / total) * 100).round(1)
       end
 

--- a/lib/rails_error_dashboard/queries/baseline_stats.rb
+++ b/lib/rails_error_dashboard/queries/baseline_stats.rb
@@ -121,8 +121,8 @@ module RailsErrorDashboard
       # Events so far in the current hour / day / week, counted in the same
       # units the baselines were built from (Services::BaselineCalculator).
       # @return [Hash] { hourly: Integer, daily: Integer, weekly: Integer }
-      def current_counts
-        relation = Services::BaselineCalculator.counting_relation(@error_type, @platform)
+      def current_counts(application_id: nil)
+        relation = Services::BaselineCalculator.counting_relation(@error_type, @platform, application_id: application_id)
         column = Services::BaselineCalculator.time_column
         now = Time.current
         {
@@ -133,8 +133,9 @@ module RailsErrorDashboard
       end
 
       # The anomaly check for right now: current counts against their baselines.
-      def check_current_anomaly(sensitivity: 2)
-        check_anomaly(sensitivity: sensitivity, **current_counts)
+      # @param application_id [Integer, nil] scope the current counts to one application
+      def check_current_anomaly(sensitivity: 2, application_id: nil)
+        check_anomaly(sensitivity: sensitivity, **current_counts(application_id: application_id))
       end
     end
   end

--- a/lib/rails_error_dashboard/queries/baseline_stats.rb
+++ b/lib/rails_error_dashboard/queries/baseline_stats.rb
@@ -85,22 +85,56 @@ module RailsErrorDashboard
       # @param current_count [Integer] Current error count
       # @param sensitivity [Integer] Standard deviations threshold (default: 2)
       # @return [Hash] { anomaly: true/false, level: Symbol, baseline_type: String }
-      def check_anomaly(current_count, sensitivity: 2)
-        baseline = hourly_baseline || daily_baseline || weekly_baseline
+      # Compare a count against the first available baseline, in matching
+      # units: the current HOUR's count against the hourly baseline, TODAY's
+      # against the daily, THIS WEEK's against the weekly. A bare positional
+      # count is compared against whichever baseline is found (legacy callers).
+      #
+      # @param current_count [Integer, nil] legacy: one count used for any baseline
+      # @param hourly [Integer, nil] events so far this hour
+      # @param daily [Integer, nil] events so far today
+      # @param weekly [Integer, nil] events so far this week
+      def check_anomaly(current_count = nil, sensitivity: 2, hourly: nil, daily: nil, weekly: nil)
+        candidates = [
+          [ hourly_baseline, hourly || current_count ],
+          [ daily_baseline, daily || current_count ],
+          [ weekly_baseline, weekly || current_count ]
+        ]
+        baseline, count = candidates.find { |b, c| b && c }
 
         if baseline.nil?
           return { anomaly: false, level: nil, baseline_type: nil, message: "No baseline available" }
         end
 
-        level = baseline.anomaly_level(current_count, sensitivity: sensitivity)
+        level = baseline.anomaly_level(count, sensitivity: sensitivity)
 
         {
           anomaly: level.present?,
           level: level,
           baseline_type: baseline.baseline_type,
+          current_count: count,
           threshold: baseline.threshold(sensitivity: sensitivity),
-          std_devs_above: baseline.std_devs_above_mean(current_count)
+          std_devs_above: baseline.std_devs_above_mean(count)
         }
+      end
+
+      # Events so far in the current hour / day / week, counted in the same
+      # units the baselines were built from (Services::BaselineCalculator).
+      # @return [Hash] { hourly: Integer, daily: Integer, weekly: Integer }
+      def current_counts
+        relation = Services::BaselineCalculator.counting_relation(@error_type, @platform)
+        column = Services::BaselineCalculator.time_column
+        now = Time.current
+        {
+          hourly: relation.where("#{column} >= ?", now.beginning_of_hour).count,
+          daily: relation.where("#{column} >= ?", now.beginning_of_day).count,
+          weekly: relation.where("#{column} >= ?", now.beginning_of_week).count
+        }
+      end
+
+      # The anomaly check for right now: current counts against their baselines.
+      def check_current_anomaly(sensitivity: 2)
+        check_anomaly(sensitivity: sensitivity, **current_counts)
       end
     end
   end

--- a/lib/rails_error_dashboard/queries/dashboard_stats.rb
+++ b/lib/rails_error_dashboard/queries/dashboard_stats.rb
@@ -181,14 +181,7 @@ module RailsErrorDashboard
 
         # Check most common error types for anomalies
         base_scope.distinct.pluck(:error_type, :platform).compact.any? do |(error_type, platform)|
-          stats = Queries::BaselineStats.new(error_type, platform)
-          error_count = base_scope.where(
-            error_type: error_type,
-            platform: platform
-          ).where("occurred_at >= ?", Time.current.beginning_of_day).count
-
-          result = stats.check_anomaly(error_count, sensitivity: 2)
-          result[:anomaly]
+          Queries::BaselineStats.new(error_type, platform).check_current_anomaly(sensitivity: 2)[:anomaly]
         end
       end
 
@@ -198,19 +191,13 @@ module RailsErrorDashboard
 
         # Find the most anomalous error type
         anomalies = base_scope.distinct.pluck(:error_type, :platform).compact.map do |(error_type, platform)|
-          stats = Queries::BaselineStats.new(error_type, platform)
-          error_count = base_scope.where(
-            error_type: error_type,
-            platform: platform
-          ).where("occurred_at >= ?", Time.current.beginning_of_day).count
-
-          result = stats.check_anomaly(error_count, sensitivity: 2)
+          result = Queries::BaselineStats.new(error_type, platform).check_current_anomaly(sensitivity: 2)
           next unless result[:anomaly]
 
           {
             error_type: error_type,
             platform: platform,
-            count: error_count,
+            count: result[:current_count],
             level: result[:level],
             std_devs_above: result[:std_devs_above]
           }

--- a/lib/rails_error_dashboard/queries/dashboard_stats.rb
+++ b/lib/rails_error_dashboard/queries/dashboard_stats.rb
@@ -181,7 +181,8 @@ module RailsErrorDashboard
 
         # Check most common error types for anomalies
         base_scope.distinct.pluck(:error_type, :platform).compact.any? do |(error_type, platform)|
-          Queries::BaselineStats.new(error_type, platform).check_current_anomaly(sensitivity: 2)[:anomaly]
+          Queries::BaselineStats.new(error_type, platform)
+                                .check_current_anomaly(sensitivity: 2, application_id: @application_id)[:anomaly]
         end
       end
 
@@ -191,7 +192,8 @@ module RailsErrorDashboard
 
         # Find the most anomalous error type
         anomalies = base_scope.distinct.pluck(:error_type, :platform).compact.map do |(error_type, platform)|
-          result = Queries::BaselineStats.new(error_type, platform).check_current_anomaly(sensitivity: 2)
+          result = Queries::BaselineStats.new(error_type, platform)
+                                         .check_current_anomaly(sensitivity: 2, application_id: @application_id)
           next unless result[:anomaly]
 
           {

--- a/lib/rails_error_dashboard/queries/release_timeline.rb
+++ b/lib/rails_error_dashboard/queries/release_timeline.rb
@@ -4,7 +4,18 @@ module RailsErrorDashboard
   module Queries
     # Query: Build a release timeline from error data, showing per-version health stats,
     # "new in this release" error detection, stability indicators, and release-over-release deltas.
-    # Uses existing app_version and git_sha columns on error_logs — no new migration needed.
+    #
+    # Counting unit: OCCURRENCES. An ErrorLog row is a group that keeps the
+    # release of its first capture, so counting rows attributed every later
+    # recurrence to that first release. Each occurrence carries the release it
+    # happened under (since the add_release_to_error_occurrences migration);
+    # before that migration is applied the query falls back to counting group
+    # rows as it always did. "New in this release" stays group-based on
+    # purpose: a group's first release IS where the error was new.
+    #
+    # Storm count-only events create no occurrence rows, so a release's total
+    # here is the number of captured events, which storm shedding can leave
+    # below the group's occurrence_count.
     class ReleaseTimeline
       def self.call(days = 30, application_id: nil)
         new(days, application_id: application_id).call
@@ -77,6 +88,8 @@ module RailsErrorDashboard
 
       # Single GROUP BY query for per-version aggregates
       def aggregate_version_stats
+        return aggregate_occurrence_stats if occurrences_carry_release?
+
         rows = base_scope
           .group(:app_version)
           .select(
@@ -116,6 +129,64 @@ module RailsErrorDashboard
         end
       rescue => e
         Rails.logger.error("[RailsErrorDashboard] ReleaseTimeline aggregate failed: #{e.class}: #{e.message}")
+        {}
+      end
+
+      def occurrences_carry_release?
+        defined?(ErrorOccurrence) && ErrorOccurrence.table_exists? &&
+          ErrorOccurrence.column_names.include?("app_version")
+      rescue
+        false
+      end
+
+      def occurrence_scope
+        occurrences = ErrorOccurrence.table_name
+        scope = ErrorOccurrence.joins(:error_log)
+                               .where("#{occurrences}.occurred_at >= ?", @start_date)
+                               .where.not(occurrences => { app_version: [ nil, "" ] })
+        scope = scope.where(ErrorLog.table_name => { application_id: @application_id }) if @application_id.present?
+        scope
+      end
+
+      def aggregate_occurrence_stats
+        occurrences = ErrorOccurrence.table_name
+        logs = ErrorLog.table_name
+
+        rows = occurrence_scope
+          .group("#{occurrences}.app_version")
+          .select(
+            "#{occurrences}.app_version AS app_version",
+            "COUNT(*) AS total_count",
+            "COUNT(DISTINCT #{logs}.error_type) AS unique_types",
+            "MIN(#{occurrences}.occurred_at) AS first_seen_at",
+            "MAX(#{occurrences}.occurred_at) AS last_seen_at"
+          )
+
+        sha_map = {}
+        occurrence_scope.where.not(occurrences => { git_sha: [ nil, "" ] })
+                        .group("#{occurrences}.app_version", "#{occurrences}.git_sha")
+                        .pluck("#{occurrences}.app_version", "#{occurrences}.git_sha")
+                        .each do |version, sha|
+                          (sha_map[version] ||= []) << sha
+                        end
+        sha_map.each_value(&:uniq!)
+
+        rows.each_with_object({}) do |row, result|
+          first_seen = row.first_seen_at
+          last_seen = row.last_seen_at
+          first_seen = Time.zone.parse(first_seen) if first_seen.is_a?(String)
+          last_seen = Time.zone.parse(last_seen) if last_seen.is_a?(String)
+
+          result[row.app_version] = {
+            total_errors: row.total_count.to_i,
+            unique_error_types: row.unique_types.to_i,
+            first_seen: first_seen,
+            last_seen: last_seen,
+            git_shas: sha_map[row.app_version] || []
+          }
+        end
+      rescue => e
+        Rails.logger.error("[RailsErrorDashboard] ReleaseTimeline occurrence aggregate failed: #{e.class}: #{e.message}")
         {}
       end
 

--- a/lib/rails_error_dashboard/services/baseline_calculator.rb
+++ b/lib/rails_error_dashboard/services/baseline_calculator.rb
@@ -72,52 +72,65 @@ module RailsErrorDashboard
         defined?(ErrorBaseline) && ErrorBaseline.table_exists?
       end
 
-      # Calculate hourly baseline (last 4 weeks, by hour of day)
+      # The events a baseline is built from: occurrences of this error type on
+      # this platform (one row per captured event) when the occurrences table
+      # exists, else the group rows themselves. Public so the anomaly check
+      # counts the current period in exactly the same units.
+      def self.counting_relation(error_type, platform)
+        if defined?(ErrorOccurrence) && ErrorOccurrence.table_exists?
+          ErrorOccurrence.joins(:error_log)
+                         .where(ErrorLog.table_name => { error_type: error_type, platform: platform })
+        else
+          ErrorLog.where(error_type: error_type, platform: platform)
+        end
+      end
+
+      # The timestamp column of #counting_relation, qualified for the join.
+      def self.time_column
+        if defined?(ErrorOccurrence) && ErrorOccurrence.table_exists?
+          "#{ErrorOccurrence.table_name}.occurred_at"
+        else
+          "occurred_at"
+        end
+      end
+
+      # Calculate hourly baseline (last 4 weeks, one sample per calendar hour)
       def calculate_hourly_baseline(error_type, platform)
-        period_start = HOURLY_LOOKBACK.ago.beginning_of_hour
-        period_end = Time.current.beginning_of_hour
-
-        # Get error counts grouped by hour
-        hourly_counts = ErrorLog
-          .where(error_type: error_type, platform: platform)
-          .where("occurred_at >= ?", period_start)
-          .group("strftime('%H', occurred_at)")
-          .count
-
-        return nil if hourly_counts.empty?
-
-        counts = hourly_counts.values
-        stats = calculate_statistics(counts)
-
-        baseline = Commands::UpsertBaseline.call(
-          error_type: error_type, platform: platform, baseline_type: "hourly",
-          period_start: period_start, period_end: period_end,
-          stats: stats, count: counts.sum, sample_size: counts.size
-        )
-
-        @calculated_count += 1
-        baseline
+        calculate_baseline(error_type, platform, "hourly", :hour,
+                           HOURLY_LOOKBACK.ago.beginning_of_hour, Time.current.beginning_of_hour)
       end
 
-      # Calculate daily baseline (last 12 weeks, by day of week)
+      # Calculate daily baseline (last 12 weeks, one sample per calendar day)
       def calculate_daily_baseline(error_type, platform)
-        period_start = DAILY_LOOKBACK.ago.beginning_of_day
-        period_end = Time.current.beginning_of_day
+        calculate_baseline(error_type, platform, "daily", :day,
+                           DAILY_LOOKBACK.ago.beginning_of_day, Time.current.beginning_of_day)
+      end
 
-        # Get error counts grouped by day
-        daily_counts = ErrorLog
-          .where(error_type: error_type, platform: platform)
-          .where("occurred_at >= ?", period_start)
-          .group("DATE(occurred_at)")
-          .count
+      # Calculate weekly baseline (last 1 year, one sample per calendar week)
+      def calculate_weekly_baseline(error_type, platform)
+        calculate_baseline(error_type, platform, "weekly", :week,
+                           WEEKLY_LOOKBACK.ago.beginning_of_week, Time.current.beginning_of_week)
+      end
 
-        return nil if daily_counts.empty?
+      # One sample per DATED bucket across the whole lookback, zero buckets
+      # included, so the statistics describe "how many events in an hour /
+      # day / week" — the unit the anomaly check compares against.
+      #
+      # The previous implementation grouped four weeks by hour-of-day, which
+      # summed 28 days into at most 24 totals (seven noon failures on seven
+      # days: mean 7, sample size 1), dropped quiet periods, and embedded a
+      # SQLite-only date function so it could not run on PostgreSQL or MySQL
+      # at all. Groupdate does the bucketing per adapter.
+      def calculate_baseline(error_type, platform, baseline_type, period, period_start, period_end)
+        return nil if period_end <= period_start
 
-        counts = daily_counts.values
+        counts = bucket_counts(error_type, platform, period, period_start, period_end)
+        return nil if counts.sum.zero?
+
         stats = calculate_statistics(counts)
 
         baseline = Commands::UpsertBaseline.call(
-          error_type: error_type, platform: platform, baseline_type: "daily",
+          error_type: error_type, platform: platform, baseline_type: baseline_type,
           period_start: period_start, period_end: period_end,
           stats: stats, count: counts.sum, sample_size: counts.size
         )
@@ -126,31 +139,12 @@ module RailsErrorDashboard
         baseline
       end
 
-      # Calculate weekly baseline (last 1 year, by week)
-      def calculate_weekly_baseline(error_type, platform)
-        period_start = WEEKLY_LOOKBACK.ago.beginning_of_week
-        period_end = Time.current.beginning_of_week
-
-        # Get error counts grouped by week
-        weekly_counts = ErrorLog
-          .where(error_type: error_type, platform: platform)
-          .where("occurred_at >= ?", period_start)
-          .group("strftime('%Y-%W', occurred_at)")
-          .count
-
-        return nil if weekly_counts.empty?
-
-        counts = weekly_counts.values
-        stats = calculate_statistics(counts)
-
-        baseline = Commands::UpsertBaseline.call(
-          error_type: error_type, platform: platform, baseline_type: "weekly",
-          period_start: period_start, period_end: period_end,
-          stats: stats, count: counts.sum, sample_size: counts.size
-        )
-
-        @calculated_count += 1
-        baseline
+      # @return [Array<Integer>] one count per bucket in [period_start, period_end)
+      def bucket_counts(error_type, platform, period, period_start, period_end)
+        self.class.counting_relation(error_type, platform)
+            .group_by_period(period, self.class.time_column, range: period_start...period_end)
+            .count
+            .values
       end
 
       # === Pure algorithm methods (no database access) ===
@@ -168,9 +162,12 @@ module RailsErrorDashboard
       def self.calculate_statistics(counts)
         return default_stats if counts.empty?
 
-        # Remove outliers
+        # Remove outliers (a storm hour must not become the baseline) — but
+        # never the whole signal: for a rare error most zero-filled buckets
+        # are 0, the few 1s sit many sigmas out, and trimming them would
+        # leave a baseline that says the error never happens.
         clean_counts = remove_outliers(counts)
-        return default_stats if clean_counts.empty?
+        clean_counts = counts if clean_counts.empty? || (clean_counts.sum.zero? && counts.sum.positive?)
 
         mean = clean_counts.sum.to_f / clean_counts.size
         variance = clean_counts.map { |c| (c - mean)**2 }.sum / clean_counts.size

--- a/lib/rails_error_dashboard/services/baseline_calculator.rb
+++ b/lib/rails_error_dashboard/services/baseline_calculator.rb
@@ -76,12 +76,19 @@ module RailsErrorDashboard
       # this platform (one row per captured event) when the occurrences table
       # exists, else the group rows themselves. Public so the anomaly check
       # counts the current period in exactly the same units.
-      def self.counting_relation(error_type, platform)
+      #
+      # @param application_id [Integer, nil] restrict to one application's
+      #   events (the baselines themselves have no application dimension;
+      #   the current-period observation must still be scoped, or one app's
+      #   spike shows up as an anomaly on another app's dashboard)
+      def self.counting_relation(error_type, platform, application_id: nil)
+        conditions = { error_type: error_type, platform: platform }
+        conditions[:application_id] = application_id if application_id.present?
+
         if defined?(ErrorOccurrence) && ErrorOccurrence.table_exists?
-          ErrorOccurrence.joins(:error_log)
-                         .where(ErrorLog.table_name => { error_type: error_type, platform: platform })
+          ErrorOccurrence.joins(:error_log).where(ErrorLog.table_name => conditions)
         else
-          ErrorLog.where(error_type: error_type, platform: platform)
+          ErrorLog.where(conditions)
         end
       end
 
@@ -140,9 +147,18 @@ module RailsErrorDashboard
       end
 
       # @return [Array<Integer>] one count per bucket in [period_start, period_end)
+      #
+      # Week boundaries and time zone are passed explicitly so the buckets
+      # line up with the Rails `beginning_of_week` / `Time.current` calls the
+      # period bounds and the anomaly check use. Groupdate's own default week
+      # starts on Sunday; Rails' starts on Monday, and with the two disagreeing
+      # a Sunday event and a Monday event landed in one bucket instead of two.
       def bucket_counts(error_type, platform, period, period_start, period_end)
+        options = { range: period_start...period_end, time_zone: Time.zone }
+        options[:week_start] = Date.beginning_of_week if period == :week # groupdate rejects it for other periods
+
         self.class.counting_relation(error_type, platform)
-            .group_by_period(period, self.class.time_column, range: period_start...period_end)
+            .group_by_period(period, self.class.time_column, **options)
             .count
             .values
       end

--- a/lib/rails_error_dashboard/services/error_hash_generator.rb
+++ b/lib/rails_error_dashboard/services/error_hash_generator.rb
@@ -67,11 +67,20 @@ module RailsErrorDashboard
         Digest::SHA256.hexdigest(digest_input)[0..15]
       end
 
+      # Only this many leading characters of the RAW message take part in the
+      # hash. The storm gate stores a bounded exemplar (it must stay cheap and
+      # memory-bounded per fingerprint), so the full path has to hash the same
+      # prefix or a long-message error would change identity the moment the
+      # breaker changed state. Truncation happens BEFORE normalization so both
+      # paths see byte-identical input.
+      HASH_MESSAGE_LIMIT = 500
+
       # Normalize dynamic values in error messages for consistent hashing
       # @param message [String, nil] The error message
       # @return [String, nil] Normalized message
       def self.normalize_message(message)
         message
+          &.[](0, HASH_MESSAGE_LIMIT)
           &.gsub(/0x[0-9a-f]+/i, "HEX")          # Replace hex addresses (before numbers)
           &.gsub(/#<[^>]+>/, "#<OBJ>")           # Replace object inspections
           &.gsub(/\d+/, "N")                     # Replace numbers

--- a/lib/rails_error_dashboard/services/local_variable_capturer.rb
+++ b/lib/rails_error_dashboard/services/local_variable_capturer.rb
@@ -10,7 +10,10 @@ module RailsErrorDashboard
     #
     # Safety contract:
     # - Default OFF (opt-in via config.enable_local_variables / enable_instance_variables)
-    # - Never stores Binding objects or object references — extracts vars immediately in callback
+    # - Never stores Binding objects — extracts vars immediately in callback
+    # - Strings, arrays and hashes are snapshotted (shallow copy, bounded by the
+    #   serializer's limits) at raise time; other objects are kept by reference,
+    #   so their state is whatever it is when the error is serialized
     # - Every callback wrapped in rescue => e (never raises)
     # - Per-variable rescue in extraction
     # - Skips SystemExit, SignalException, Interrupt
@@ -117,6 +120,33 @@ module RailsErrorDashboard
           end
         end
 
+        # A value as it is NOW, for the kinds of value that are cheap to copy.
+        #
+        # The exception is serialized later, after the stack has unwound —
+        # and ensure blocks and rescue handlers run in between, mutating the
+        # very state worth seeing (`state["phase"] = "cleanup"`, `@conn = nil`).
+        # A reference would show the post-cleanup value and call it the value
+        # "at raise". Strings, arrays and hashes get a one-level copy, bounded
+        # by what the serializer will keep anyway (+1 so it still knows the
+        # original was longer). Anything else is left as a reference: copying
+        # arbitrary application objects is neither safe nor cheap. Nested
+        # containers inside the copy are therefore still references.
+        def snapshot_value(value)
+          config = RailsErrorDashboard.configuration
+          case value
+          when String
+            value.frozen? ? value : value[0, (config.local_variable_max_string_length || 200) + 1]
+          when Array
+            value.first((config.local_variable_max_array_items || 10) + 1)
+          when Hash
+            value.first((config.local_variable_max_hash_items || 20) + 1).to_h
+          else
+            value
+          end
+        rescue
+          value
+        end
+
         # Check if the path should be skipped (gem code, vendor, stdlib, this gem)
         def skip_path?(path)
           path.include?("/gems/") ||
@@ -142,7 +172,7 @@ module RailsErrorDashboard
 
           locals = {}
           var_names.each do |name|
-            locals[name] = binding_obj.local_variable_get(name)
+            locals[name] = snapshot_value(binding_obj.local_variable_get(name))
           rescue => e
             locals[name] = "(extraction error: #{e.class.name})"
           end
@@ -189,7 +219,7 @@ module RailsErrorDashboard
 
           # Extract each instance variable (per-variable rescue)
           ivar_names.each do |name|
-            result[name] = obj.instance_variable_get(name)
+            result[name] = snapshot_value(obj.instance_variable_get(name))
           rescue => e
             result[name] = "(extraction error: #{e.class.name})"
           end

--- a/lib/rails_error_dashboard/services/storm_protection/count_buffer.rb
+++ b/lib/rails_error_dashboard/services/storm_protection/count_buffer.rb
@@ -17,8 +17,14 @@ module RailsErrorDashboard
       # Memory: bounded map; beyond the cap events land in a single overflow
       # counter (still exact in total, anonymous in identity).
       #
-      # Concurrency: snapshot! atomically swaps the whole map out via
-      # AtomicReference, so flushing never races with recording.
+      # Concurrency: a read/write lock. Every record holds the READ lock for
+      # the few instructions between reading the map reference and bumping
+      # the entry's counter; snapshot! takes the WRITE lock only to swap the
+      # map out. So once the swap returns no writer can still be holding the
+      # old map, and the old map is quiescent while it is serialized outside
+      # the lock. AtomicReference alone was not enough: a writer that read the
+      # old reference just before the swap would increment a map nobody would
+      # ever read again, and the "exact" count lost an event.
       class CountBuffer
         Entry = Struct.new(
           :error_class, :message, :first_app_frame,
@@ -31,6 +37,7 @@ module RailsErrorDashboard
         end
 
         def reset!
+          @lock = Concurrent::ReadWriteLock.new
           @map_ref = Concurrent::AtomicReference.new(Concurrent::Map.new)
           @overflow = Concurrent::AtomicFixnum.new(0)
         end
@@ -39,25 +46,31 @@ module RailsErrorDashboard
         # @param gate_key [String] cheap in-process bucketing key
         # @param parts [Hash] identity parts captured at the gate
         def record(gate_key, parts)
-          map = @map_ref.get
-          entry = map[gate_key]
+          @lock.with_read_lock { add(gate_key, parts, 1, Time.current, Time.current) }
+        end
 
-          unless entry
-            if map.size >= max_tracked
-              @overflow.increment
-              return
-            end
-            entry = map.compute_if_absent(gate_key) do
-              Entry.new(
-                parts[:error_class], parts[:message], parts[:first_app_frame],
-                parts[:controller_name], parts[:action_name], parts[:custom_hash],
-                Concurrent::AtomicFixnum.new(0), Time.current, Time.current
+        # Put a snapshot BACK when its handoff failed (the flush job could not
+        # be enqueued). Counts merge into whatever accumulated since the swap;
+        # first_seen_at keeps the earliest of the two; beyond the map cap the
+        # events land in the overflow bucket — exact in total, as always.
+        # @param entries [Array<Hash>] entries from #snapshot!
+        # @param overflow [Integer] overflow from #snapshot!
+        def restore(entries, overflow = 0)
+          @lock.with_read_lock do
+            Array(entries).each do |entry|
+              entry = entry.with_indifferent_access if entry.respond_to?(:with_indifferent_access)
+              next unless entry.is_a?(Hash)
+
+              add(
+                entry["gate_key"],
+                parts_from(entry),
+                entry["count"].to_i,
+                parse_time(entry["first_seen_at"]),
+                parse_time(entry["last_seen_at"])
               )
             end
+            @overflow.increment(overflow.to_i) if overflow.to_i.positive?
           end
-
-          entry.count.increment
-          entry.last_seen_at = Time.current
         end
 
         def any?
@@ -67,13 +80,16 @@ module RailsErrorDashboard
         # Atomically swap the buffer out and return serializable entry hashes.
         # @return [Hash] { entries: Array<Hash>, overflow: Integer }
         def snapshot!
-          old_map = @map_ref.get_and_set(Concurrent::Map.new)
-          overflow = @overflow.value
-          @overflow.update { |v| v - overflow }
+          old_map, overflow = @lock.with_write_lock do
+            taken = @overflow.value
+            @overflow.update { |v| v - taken }
+            [ @map_ref.get_and_set(Concurrent::Map.new), taken ]
+          end
 
           entries = []
-          old_map.each_pair do |_key, entry|
+          old_map.each_pair do |key, entry|
             entries << {
+              "gate_key" => key,
               "error_class" => entry.error_class,
               "message" => entry.message,
               "first_app_frame" => entry.first_app_frame,
@@ -90,6 +106,49 @@ module RailsErrorDashboard
         end
 
         private
+
+        # Callers hold the read lock.
+        def add(gate_key, parts, count, first_seen_at, last_seen_at)
+          return if count <= 0
+
+          map = @map_ref.get
+          entry = map[gate_key]
+
+          unless entry
+            if map.size >= max_tracked
+              @overflow.increment(count)
+              return
+            end
+            entry = map.compute_if_absent(gate_key) do
+              Entry.new(
+                parts[:error_class], parts[:message], parts[:first_app_frame],
+                parts[:controller_name], parts[:action_name], parts[:custom_hash],
+                Concurrent::AtomicFixnum.new(0), first_seen_at || Time.current, last_seen_at || Time.current
+              )
+            end
+          end
+
+          entry.count.increment(count)
+          entry.last_seen_at = [ entry.last_seen_at, last_seen_at ].compact.max
+          entry.first_seen_at = [ entry.first_seen_at, first_seen_at ].compact.min
+        end
+
+        def parts_from(entry)
+          {
+            error_class: entry["error_class"], message: entry["message"],
+            first_app_frame: entry["first_app_frame"], controller_name: entry["controller_name"],
+            action_name: entry["action_name"], custom_hash: entry["custom_hash"]
+          }
+        end
+
+        def parse_time(value)
+          return value if value.is_a?(Time) || value.is_a?(ActiveSupport::TimeWithZone)
+          return nil if value.blank?
+
+          Time.zone.parse(value.to_s)
+        rescue ArgumentError
+          nil
+        end
 
         def max_tracked
           RailsErrorDashboard.configuration.storm_max_tracked_fingerprints.to_i

--- a/lib/rails_error_dashboard/services/storm_protection/count_buffer.rb
+++ b/lib/rails_error_dashboard/services/storm_protection/count_buffer.rb
@@ -28,7 +28,7 @@ module RailsErrorDashboard
       class CountBuffer
         Entry = Struct.new(
           :error_class, :message, :first_app_frame,
-          :controller_name, :action_name, :custom_hash,
+          :controller_name, :action_name, :custom_hash, :environment,
           :count, :first_seen_at, :last_seen_at
         )
 
@@ -96,6 +96,7 @@ module RailsErrorDashboard
               "controller_name" => entry.controller_name,
               "action_name" => entry.action_name,
               "custom_hash" => entry.custom_hash,
+              "environment" => entry.environment,
               "count" => entry.count.value,
               "first_seen_at" => entry.first_seen_at.iso8601,
               "last_seen_at" => entry.last_seen_at.iso8601
@@ -122,7 +123,7 @@ module RailsErrorDashboard
             entry = map.compute_if_absent(gate_key) do
               Entry.new(
                 parts[:error_class], parts[:message], parts[:first_app_frame],
-                parts[:controller_name], parts[:action_name], parts[:custom_hash],
+                parts[:controller_name], parts[:action_name], parts[:custom_hash], parts[:environment],
                 Concurrent::AtomicFixnum.new(0), first_seen_at || Time.current, last_seen_at || Time.current
               )
             end
@@ -137,7 +138,8 @@ module RailsErrorDashboard
           {
             error_class: entry["error_class"], message: entry["message"],
             first_app_frame: entry["first_app_frame"], controller_name: entry["controller_name"],
-            action_name: entry["action_name"], custom_hash: entry["custom_hash"]
+            action_name: entry["action_name"], custom_hash: entry["custom_hash"],
+            environment: entry["environment"]
           }
         end
 

--- a/lib/rails_error_dashboard/services/storm_protection/gate.rb
+++ b/lib/rails_error_dashboard/services/storm_protection/gate.rb
@@ -203,16 +203,29 @@ module RailsErrorDashboard
             @last_flush = now
             snapshot = count_buffer.snapshot!
             episode = breaker.episode_snapshot
-            breaker.clear_closed_episode!
 
-            StormFlushJob.perform_later(
-              entries: snapshot[:entries],
-              overflow: snapshot[:overflow],
-              episode: serialize_episode(episode)
-            )
+            begin
+              StormFlushJob.perform_later(
+                entries: snapshot[:entries],
+                overflow: snapshot[:overflow],
+                episode: serialize_episode(episode)
+              )
+            rescue => e
+              # The queue is often the very thing that is down during a storm
+              # (a SolidQueue enqueue is a DB write). The batch is not gone:
+              # put it back so the next interval retries, and leave the
+              # closed episode in place so it is persisted by that retry.
+              count_buffer.restore(snapshot[:entries], snapshot[:overflow])
+              RailsErrorDashboard::Logger.error(
+                "[RailsErrorDashboard] Storm flush enqueue failed (batch retained for retry): #{e.class} - #{e.message}"
+              )
+              return
+            end
+
+            breaker.clear_closed_episode!
           rescue => e
             RailsErrorDashboard::Logger.error(
-              "[RailsErrorDashboard] Storm flush enqueue failed: #{e.class} - #{e.message}"
+              "[RailsErrorDashboard] Storm flush failed: #{e.class} - #{e.message}"
             )
           end
 

--- a/lib/rails_error_dashboard/services/storm_protection/gate.rb
+++ b/lib/rails_error_dashboard/services/storm_protection/gate.rb
@@ -205,11 +205,18 @@ module RailsErrorDashboard
             episode = breaker.episode_snapshot
 
             begin
-              StormFlushJob.perform_later(
+              job = StormFlushJob.perform_later(
                 entries: snapshot[:entries],
                 overflow: snapshot[:overflow],
                 episode: serialize_episode(episode)
               )
+              # Active Job swallows ActiveJob::EnqueueError and returns false
+              # (and a job that was not enqueued says so) — a failed handoff
+              # that never raises.
+              unless enqueued?(job)
+                reason = (job.respond_to?(:enqueue_error) && job.enqueue_error&.message) || "enqueue returned #{job.inspect}"
+                raise "StormFlushJob was not enqueued: #{reason}"
+              end
             rescue => e
               # The queue is often the very thing that is down during a storm
               # (a SolidQueue enqueue is a DB write). The batch is not gone:
@@ -227,6 +234,13 @@ module RailsErrorDashboard
             RailsErrorDashboard::Logger.error(
               "[RailsErrorDashboard] Storm flush failed: #{e.class} - #{e.message}"
             )
+          end
+
+          def enqueued?(job)
+            return false unless job
+            return job.successfully_enqueued? if job.respond_to?(:successfully_enqueued?)
+
+            true
           end
 
           def serialize_episode(episode)

--- a/lib/rails_error_dashboard/services/storm_protection/gate.rb
+++ b/lib/rails_error_dashboard/services/storm_protection/gate.rb
@@ -165,7 +165,7 @@ module RailsErrorDashboard
           def gate_parts(exception, context)
             {
               error_class: exception.class.name,
-              message: exception.message.to_s[0, 500],
+              message: exception.message.to_s[0, ErrorHashGenerator::HASH_MESSAGE_LIMIT],
               first_app_frame: ErrorHashGenerator.extract_app_frame_from_locations(exception) ||
                                ErrorHashGenerator.extract_app_frame(exception.backtrace),
               controller_name: context[:controller_name]&.to_s,

--- a/lib/rails_error_dashboard/services/storm_protection/gate.rb
+++ b/lib/rails_error_dashboard/services/storm_protection/gate.rb
@@ -155,11 +155,20 @@ module RailsErrorDashboard
           # Cheap in-process bucketing key. Deliberately NOT the canonical
           # error_hash (that needs application_id = DB); the flush job
           # recomputes the canonical hash from the stored parts.
+          # Environment is a MATCH dimension (one row per environment), so it
+          # is part of the in-process key too: a staging event and a
+          # production event of the same error must not share one entry, or
+          # the flush job would reconcile both into whichever environment
+          # the worker runs in.
           def gate_key(parts)
-            parts[:gate_key] ||= parts[:custom_hash] || Digest::SHA256.hexdigest(
-              "#{parts[:error_class]}|#{ErrorHashGenerator.normalize_message(parts[:message])}|" \
-              "#{parts[:first_app_frame]}|#{parts[:controller_name]}|#{parts[:action_name]}"
+            parts[:gate_key] ||= Digest::SHA256.hexdigest(
+              "#{parts[:custom_hash] || identity_key(parts)}|#{parts[:environment]}"
             )[0..15]
+          end
+
+          def identity_key(parts)
+            "#{parts[:error_class]}|#{ErrorHashGenerator.normalize_message(parts[:message])}|" \
+              "#{parts[:first_app_frame]}|#{parts[:controller_name]}|#{parts[:action_name]}"
           end
 
           def gate_parts(exception, context)
@@ -170,7 +179,11 @@ module RailsErrorDashboard
                                ErrorHashGenerator.extract_app_frame(exception.backtrace),
               controller_name: context[:controller_name]&.to_s,
               action_name: context[:action_name]&.to_s,
-              custom_hash: custom_hash_for(exception, context)
+              custom_hash: custom_hash_for(exception, context),
+              # Only an EXPLICIT environment from the caller. nil means "the
+              # worker's own environment", resolved at flush time exactly as
+              # LogError resolves it for a full capture.
+              environment: context[:environment].to_s.strip.presence&.[](0, 64)
             }
           end
 

--- a/lib/rails_error_dashboard/services/system_health_snapshot.rb
+++ b/lib/rails_error_dashboard/services/system_health_snapshot.rb
@@ -8,11 +8,17 @@ module RailsErrorDashboard
     # Puma stats, job queue, RubyVM/YJIT, ActionCable, file descriptors, system load,
     # system memory pressure, GC context, and TCP connection states.
     #
-    # NOT memoized — fresh data every call (unlike EnvironmentSnapshot).
+    # NOT memoized — fresh data every call (unlike EnvironmentSnapshot), with
+    # one exception: job-queue depth counts are queries against the queue
+    # store, so they are cached per process for
+    # config.system_health_queue_stats_cache_seconds (and can be switched off
+    # with config.system_health_queue_stats = false).
     # Every metric call individually wrapped in rescue => nil.
     #
     # Safety contract (from HOST_APP_SAFETY.md):
-    # - Total snapshot < 1ms budget (~0.3ms typical on Linux)
+    # - In-process metrics < 1ms budget (~0.3ms typical on Linux). The
+    #   queue-depth counts are the documented exception: their latency is
+    #   the queue store's, which is why they are cached and optional.
     # - NEVER ObjectSpace.each_object or ObjectSpace.count_objects (heap scan)
     # - NEVER Thread.list.map(&:backtrace) (GVL hold)
     # - Thread.list.count only (O(1), safe)
@@ -133,7 +139,37 @@ module RailsErrorDashboard
 
       # Auto-detect and capture job queue stats
       # @return [Hash, nil] Job queue stats with :adapter key, or nil
+      # Process-wide cache for the queue-depth counts: { at: monotonic, stats: Hash }.
+      # Lock-free; a race between two request threads at most runs the counts twice.
+      def self.queue_stats_cache
+        @queue_stats_cache ||= Concurrent::AtomicReference.new(nil)
+      end
+
+      def self.reset_queue_stats_cache!
+        queue_stats_cache.set(nil)
+      end
+
       def job_queue_stats
+        config = RailsErrorDashboard.configuration
+        return nil unless config.system_health_queue_stats
+
+        ttl = config.system_health_queue_stats_cache_seconds.to_f
+        return collect_job_queue_stats if ttl <= 0
+
+        now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        cached = self.class.queue_stats_cache.get
+        if cached && (now - cached[:at]) < ttl
+          return cached[:stats].merge(cached_age_seconds: (now - cached[:at]).round(1))
+        end
+
+        stats = collect_job_queue_stats
+        self.class.queue_stats_cache.set({ at: now, stats: stats }) if stats
+        stats
+      rescue => e
+        nil
+      end
+
+      def collect_job_queue_stats
         if defined?(::Sidekiq::Stats)
           sidekiq_stats
         elsif defined?(::SolidQueue)

--- a/lib/rails_error_dashboard/services/system_health_snapshot.rb
+++ b/lib/rails_error_dashboard/services/system_health_snapshot.rb
@@ -11,8 +11,9 @@ module RailsErrorDashboard
     # NOT memoized — fresh data every call (unlike EnvironmentSnapshot), with
     # one exception: job-queue depth counts are queries against the queue
     # store, so they are cached per process for
-    # config.system_health_queue_stats_cache_seconds (and can be switched off
-    # with config.system_health_queue_stats = false).
+    # config.system_health_queue_stats_cache_seconds (failures included), with
+    # one refresh in flight at a time (and can be switched off with
+    # config.system_health_queue_stats = false).
     # Every metric call individually wrapped in rescue => nil.
     #
     # Safety contract (from HOST_APP_SAFETY.md):
@@ -139,10 +140,19 @@ module RailsErrorDashboard
 
       # Auto-detect and capture job queue stats
       # @return [Hash, nil] Job queue stats with :adapter key, or nil
-      # Process-wide cache for the queue-depth counts: { at: monotonic, stats: Hash }.
-      # Lock-free; a race between two request threads at most runs the counts twice.
+      # Process-wide cache for the queue-depth counts: { at: monotonic, stats: Hash|nil }.
+      # A nil stats entry is a FAILED collection, cached for the same interval
+      # so a broken queue store is not re-queried on every error.
       def self.queue_stats_cache
         @queue_stats_cache ||= Concurrent::AtomicReference.new(nil)
+      end
+
+      # Single-flight guard for the refresh. Never blocks: a thread that finds
+      # a refresh already running serves the stale entry (or nil) instead of
+      # starting a second one, so a burst of errors on a cold cache runs the
+      # queue counts once, not once per thread.
+      def self.queue_stats_refresh_lock
+        @queue_stats_refresh_lock ||= Mutex.new
       end
 
       def self.reset_queue_stats_cache!
@@ -158,15 +168,28 @@ module RailsErrorDashboard
 
         now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         cached = self.class.queue_stats_cache.get
-        if cached && (now - cached[:at]) < ttl
-          return cached[:stats].merge(cached_age_seconds: (now - cached[:at]).round(1))
-        end
+        return present_cached(cached, now) if cached && (now - cached[:at]) < ttl
 
-        stats = collect_job_queue_stats
-        self.class.queue_stats_cache.set({ at: now, stats: stats }) if stats
-        stats
+        lock = self.class.queue_stats_refresh_lock
+        return present_cached(cached, now, stale: true) unless lock.try_lock
+
+        begin
+          stats = collect_job_queue_stats
+          self.class.queue_stats_cache.set({ at: now, stats: stats })
+          stats
+        ensure
+          lock.unlock
+        end
       rescue => e
         nil
+      end
+
+      def present_cached(cached, now, stale: false)
+        return nil unless cached && cached[:stats]
+
+        presented = cached[:stats].merge(cached_age_seconds: (now - cached[:at]).round(1))
+        presented[:stale] = true if stale
+        presented
       end
 
       def collect_job_queue_stats

--- a/lib/rails_error_dashboard/value_objects/error_context.rb
+++ b/lib/rails_error_dashboard/value_objects/error_context.rb
@@ -7,7 +7,7 @@ module RailsErrorDashboard
     class ErrorContext
       attr_reader :user_id, :request_url, :request_params, :user_agent, :ip_address, :platform,
                   :controller_name, :action_name, :request_id, :session_id,
-                  :http_method, :hostname, :content_type, :request_duration_ms
+                  :http_method, :hostname, :content_type, :request_duration_ms, :environment
 
       def initialize(context, source = nil)
         @context = context
@@ -27,8 +27,15 @@ module RailsErrorDashboard
         @hostname = extract_hostname
         @content_type = extract_content_type
         @request_duration_ms = extract_request_duration_ms
+        @environment = extract_environment
       end
 
+      # Everything a second ErrorContext needs to rebuild THIS context from a
+      # plain hash. ErrorReporter hands `to_h` to LogError, which constructs a
+      # new ErrorContext from it, so any reader that is not represented here
+      # is silently nil on the far side of that hop. request_id/session_id
+      # were exactly that: extracted from the request, dropped here, and every
+      # occurrence on the main capture path stored nil for both.
       def to_h
         {
           user_id: user_id,
@@ -39,10 +46,13 @@ module RailsErrorDashboard
           platform: platform,
           controller_name: controller_name,
           action_name: action_name,
+          request_id: request_id,
+          session_id: session_id,
           http_method: http_method,
           hostname: hostname,
           content_type: content_type,
-          request_duration_ms: request_duration_ms
+          request_duration_ms: request_duration_ms,
+          environment: environment
         }
       end
 
@@ -244,6 +254,13 @@ module RailsErrorDashboard
         return @context[:request_duration_ms] if @context[:request_duration_ms]
 
         nil
+      end
+
+      # An explicit environment from the caller (a sender attributing an event
+      # to its own environment). nil means "resolve from configuration".
+      def extract_environment
+        value = @context[:environment].to_s.strip
+        value.empty? ? nil : value
       end
 
       # Auto-detect user_id from ActiveSupport::CurrentAttributes

--- a/spec/commands/find_or_increment_error_spec.rb
+++ b/spec/commands/find_or_increment_error_spec.rb
@@ -205,6 +205,28 @@ RSpec.describe RailsErrorDashboard::Commands::FindOrIncrementError do
     end
   end
 
+  describe "locking" do
+    it "runs the lookup and the write inside one transaction so the row lock is held across both" do
+      RailsErrorDashboard::ErrorLog.create!(base_attributes.merge(resolved: false, occurrence_count: 1))
+
+      transaction_open_during_update = nil
+      allow_any_instance_of(RailsErrorDashboard::ErrorLog).to receive(:update!).and_wrap_original do |m, *args|
+        transaction_open_during_update = RailsErrorDashboard::ErrorLog.connection.transaction_open?
+        m.call(*args)
+      end
+
+      described_class.call(error_hash, base_attributes)
+      expect(transaction_open_during_update).to be(true)
+    end
+
+    it "issues the lookup with a row lock" do
+      RailsErrorDashboard::ErrorLog.create!(base_attributes.merge(resolved: false, occurrence_count: 1))
+      relation = RailsErrorDashboard::ErrorLog.unresolved.where(error_hash: error_hash).lock
+      expect(relation.lock_value).to be(true)
+      expect(described_class.new(error_hash, base_attributes).send(:find_unresolved)).to be_present
+    end
+  end
+
   describe "environment matching" do
     let(:production) { base_attributes.merge(environment: "production") }
     let(:staging) { base_attributes.merge(environment: "staging") }

--- a/spec/commands/flush_storm_counts_spec.rb
+++ b/spec/commands/flush_storm_counts_spec.rb
@@ -92,6 +92,11 @@ RSpec.describe RailsErrorDashboard::Commands::FlushStormCounts do
   end
 
   describe "fingerprints first seen during count-only mode" do
+    it "fits over-long string metadata to its columns" do
+      described_class.call(entries: [ entry_for(error_class: "E" * 300, message: "long class", count: 1) ])
+      expect(RailsErrorDashboard::ErrorLog.find_by(message: "long class").error_type.length).to eq(255)
+    end
+
     it "creates a minimal ErrorLog from the exemplar with the exact count" do
       expect {
         described_class.call(entries: [ entry_for(message: "never stored before", count: 99) ])

--- a/spec/commands/flush_storm_counts_spec.rb
+++ b/spec/commands/flush_storm_counts_spec.rb
@@ -333,6 +333,24 @@ RSpec.describe RailsErrorDashboard::Commands::FlushStormCounts do
       expect(RailsErrorDashboard::ErrorLog.where(message: "storm boom").count).to eq(1)
     end
 
+    it "keeps an explicit staging event on the staging row even when the worker runs as production" do
+      RailsErrorDashboard.configuration.environment = "production"
+      error = StandardError.new("storm boom")
+      error.set_backtrace([ "#{Rails.root}/app/models/widget.rb:10:in 'explode'" ])
+      staging = RailsErrorDashboard::Commands::LogError.call(error, { controller_name: "widgets", action_name: "show", environment: "staging" })
+      expect(staging.environment).to eq("staging")
+
+      gate = RailsErrorDashboard::Services::StormProtection::Gate
+      parts = gate.send(:gate_parts, error, { controller_name: "widgets", action_name: "show", environment: "staging" })
+      buffer = RailsErrorDashboard::Services::StormProtection::CountBuffer.new
+      3.times { buffer.record(gate.send(:gate_key, parts), parts) }
+
+      described_class.call(entries: buffer.snapshot![:entries])
+
+      expect(staging.reload.occurrence_count).to eq(4)
+      expect(RailsErrorDashboard::ErrorLog.where(error_hash: staging.error_hash).pluck(:environment)).to eq([ "staging" ])
+    end
+
     it "creates a first-seen row carrying the environment" do
       RailsErrorDashboard.configuration.environment = "uat"
       described_class.call(entries: [ entry_for(message: "never seen before", count: 2) ])

--- a/spec/commands/flush_storm_counts_spec.rb
+++ b/spec/commands/flush_storm_counts_spec.rb
@@ -138,6 +138,40 @@ RSpec.describe RailsErrorDashboard::Commands::FlushStormCounts do
     end
   end
 
+  describe "single-row reconciliation (mirrors FindOrIncrementError's 24 h window)" do
+    def capture
+      error = StandardError.new("storm boom")
+      error.set_backtrace([ "#{Rails.root}/app/models/widget.rb:10:in 'explode'" ])
+      RailsErrorDashboard::Commands::LogError.call(error, { controller_name: "widgets", action_name: "show" })
+    end
+
+    it "increments only the current group when older unresolved groups share the hash" do
+      old_group = capture
+      old_group.update!(occurred_at: 2.days.ago, first_seen_at: 2.days.ago, last_seen_at: 2.days.ago)
+      current_group = capture
+      expect(current_group.id).not_to eq(old_group.id)
+
+      described_class.call(entries: [ entry_for(count: 5) ])
+
+      expect(current_group.reload.occurrence_count).to eq(6)
+      expect(old_group.reload.occurrence_count).to eq(1)
+      # Seven real events, seven counted occurrences.
+      expect(RailsErrorDashboard::ErrorLog.sum(:occurrence_count)).to eq(7)
+    end
+
+    it "opens a new group when every unresolved match is outside the 24 h window, like the full path" do
+      stale = capture
+      stale.update!(occurred_at: 2.days.ago, first_seen_at: 2.days.ago, last_seen_at: 2.days.ago)
+
+      expect {
+        described_class.call(entries: [ entry_for(count: 5) ])
+      }.to change(RailsErrorDashboard::ErrorLog, :count).by(1)
+
+      expect(stale.reload.occurrence_count).to eq(1)
+      expect(RailsErrorDashboard::ErrorLog.where.not(id: stale.id).first.occurrence_count).to eq(5)
+    end
+  end
+
   describe "storm_events lifecycle" do
     let(:episode) do
       { "started_at" => 2.minutes.ago.iso8601, "ended_at" => nil,

--- a/spec/commands/flush_storm_counts_spec.rb
+++ b/spec/commands/flush_storm_counts_spec.rb
@@ -100,6 +100,44 @@ RSpec.describe RailsErrorDashboard::Commands::FlushStormCounts do
     end
   end
 
+  describe "sensitive data redaction at the persistence boundary" do
+    before do
+      RailsErrorDashboard.configuration.filter_sensitive_data = true
+      RailsErrorDashboard::Services::SensitiveDataFilter.reset!
+    end
+    after { RailsErrorDashboard::Services::SensitiveDataFilter.reset! }
+
+    it "redacts a first-seen row's exemplar message exactly as the full path would" do
+      described_class.call(entries: [ entry_for(message: "login failed password=hunter2-storm", count: 4) ])
+
+      row = RailsErrorDashboard::ErrorLog.find_by(error_type: "StandardError")
+      expect(row.message).to eq("login failed password=[FILTERED]")
+      expect(row.message).not_to include("hunter2")
+    end
+
+    it "still lands a later full capture on the redacted storm-created row (hash is from the raw message)" do
+      described_class.call(entries: [ entry_for(message: "login failed password=hunter2-storm", count: 4) ])
+
+      error = StandardError.new("login failed password=hunter2-storm")
+      error.set_backtrace([ "#{Rails.root}/app/models/widget.rb:10:in 'explode'" ])
+      expect {
+        RailsErrorDashboard::Commands::LogError.call(error, { controller_name: "widgets", action_name: "show" })
+      }.not_to change(RailsErrorDashboard::ErrorLog, :count)
+
+      expect(RailsErrorDashboard::ErrorLog.first.occurrence_count).to eq(5)
+    end
+
+    it "redacts exemplar messages in the storm ledger's top fingerprints" do
+      described_class.call(
+        entries: [ entry_for(message: "token=abc123secret expired", count: 9) ],
+        episode: { "started_at" => 2.minutes.ago.iso8601, "peak_rate_per_minute" => 100, "reached_open" => true }
+      )
+
+      fingerprints = RailsErrorDashboard::StormEvent.last.top_fingerprints_list
+      expect(fingerprints.first["message"]).to eq("token=[FILTERED] expired")
+    end
+  end
+
   describe "storm_events lifecycle" do
     let(:episode) do
       { "started_at" => 2.minutes.ago.iso8601, "ended_at" => nil,

--- a/spec/commands/flush_storm_counts_spec.rb
+++ b/spec/commands/flush_storm_counts_spec.rb
@@ -43,6 +43,22 @@ RSpec.describe RailsErrorDashboard::Commands::FlushStormCounts do
       expect(RailsErrorDashboard::ErrorLog.where(message: "storm boom").count).to eq(1) # no duplicate row
     end
 
+    it "lands a long-message error on the same row (both paths hash the same 500-char prefix)" do
+      long_message = ("x" * 501) + " trailing detail that only the full path ever saw"
+      error = StandardError.new(long_message)
+      error.set_backtrace([ "#{Rails.root}/app/models/widget.rb:10:in 'explode'" ])
+      log = RailsErrorDashboard::Commands::LogError.call(error, { controller_name: "widgets", action_name: "show" })
+
+      gate_parts = RailsErrorDashboard::Services::StormProtection::Gate.send(:gate_parts, error,
+        { controller_name: "widgets", action_name: "show" })
+      expect(gate_parts[:message].length).to eq(500)
+
+      expect {
+        described_class.call(entries: [ entry_for(message: gate_parts[:message], count: 3) ])
+      }.not_to change(RailsErrorDashboard::ErrorLog, :count)
+      expect(log.reload.occurrence_count).to eq(4)
+    end
+
     it "reconciles by custom hash directly when present" do
       # Pin the same application the flush command will resolve
       app = RailsErrorDashboard::Application.find_or_create_by_name(

--- a/spec/commands/log_error_spec.rb
+++ b/spec/commands/log_error_spec.rb
@@ -1154,6 +1154,22 @@ RSpec.describe RailsErrorDashboard::Commands::LogError do
     end
     after { RailsErrorDashboard.reset_configuration! }
 
+    it "fits over-long string metadata to its columns so the capture is never lost to a length error" do
+      RailsErrorDashboard.configuration.app_version = "v" * 400
+      RailsErrorDashboard.configuration.git_sha = "s" * 300
+      error = StandardError.new("length clamp")
+      error.set_backtrace([ "app/models/widget.rb:10:in 'explode'" ])
+
+      log = described_class.call(error)
+
+      expect(log).to be_persisted
+      expect(log.app_version.length).to eq(255)
+      expect(log.git_sha.length).to eq(255)
+      occurrence = RailsErrorDashboard::ErrorOccurrence.where(error_log: log).last
+      expect(occurrence.app_version.length).to eq(255)
+      expect(occurrence.git_sha.length).to eq(255)
+    end
+
     it "records the release each occurrence happened under, while the group keeps its first release" do
       error = StandardError.new("release attribution")
       error.set_backtrace([ "app/models/widget.rb:10:in 'explode'" ])

--- a/spec/commands/log_error_spec.rb
+++ b/spec/commands/log_error_spec.rb
@@ -1146,4 +1146,28 @@ RSpec.describe RailsErrorDashboard::Commands::LogError do
       expect(log.environment).to be_nil
     end
   end
+  describe "release attribution on occurrences" do
+    before do
+      RailsErrorDashboard.configuration.async_logging = false
+      RailsErrorDashboard.configuration.app_version = "9.9.9"
+      RailsErrorDashboard.configuration.git_sha = "deadbeef"
+    end
+    after { RailsErrorDashboard.reset_configuration! }
+
+    it "records the release each occurrence happened under, while the group keeps its first release" do
+      error = StandardError.new("release attribution")
+      error.set_backtrace([ "app/models/widget.rb:10:in 'explode'" ])
+      log = described_class.call(error)
+      expect(log.app_version).to eq("9.9.9")
+
+      RailsErrorDashboard.configuration.app_version = "10.0.0"
+      RailsErrorDashboard.configuration.git_sha = "cafebabe"
+      again = described_class.call(error)
+      expect(again.id).to eq(log.id)
+      expect(again.reload.app_version).to eq("9.9.9")
+
+      versions = RailsErrorDashboard::ErrorOccurrence.where(error_log: log).order(:id).pluck(:app_version, :git_sha)
+      expect(versions).to eq([ [ "9.9.9", "deadbeef" ], [ "10.0.0", "cafebabe" ] ])
+    end
+  end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_08_26_000001) do
+ActiveRecord::Schema[7.0].define(version: 2026_09_08_000001) do
   create_table "rails_error_dashboard_rack_attack_events", force: :cascade do |t|
     t.string "rule", limit: 250, null: false
     t.string "match_type", limit: 50, null: false
@@ -213,6 +213,9 @@ ActiveRecord::Schema[7.0].define(version: 2026_08_26_000001) do
     t.string "session_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "app_version"
+    t.string "git_sha"
+    t.index [ "app_version", "occurred_at" ], name: "index_error_occurrences_on_version_and_time"
     t.index [ "error_log_id" ], name: "index_error_occurrences_on_error_log"
     t.index [ "occurred_at", "error_log_id" ], name: "index_error_occurrences_on_time_and_error"
     t.index [ "request_id" ], name: "index_error_occurrences_on_request"

--- a/spec/factories/error_logs.rb
+++ b/spec/factories/error_logs.rb
@@ -47,9 +47,17 @@ FactoryBot.define do
       reopened_at { Time.current }
     end
 
+    # A versioned capture: the group row plus the occurrence that carries the
+    # release it happened under, which is what LogError writes and what
+    # ReleaseTimeline counts.
     trait :with_version do
       app_version { "1.0.0" }
       git_sha { SecureRandom.hex(20) }
+
+      after(:create) do |log|
+        create(:error_occurrence, error_log: log, occurred_at: log.occurred_at,
+                                  app_version: log.app_version, git_sha: log.git_sha)
+      end
     end
 
     trait :with_backtrace do

--- a/spec/jobs/rails_error_dashboard/async_error_logging_job_spec.rb
+++ b/spec/jobs/rails_error_dashboard/async_error_logging_job_spec.rb
@@ -40,6 +40,50 @@ RSpec.describe RailsErrorDashboard::AsyncErrorLoggingJob, type: :job do
       expect(error_log.backtrace).to include("app/controllers/test_controller.rb:10:in `index'")
     end
 
+    context "with exception classes whose constructors do not take a message" do
+      it "keeps ActiveRecord::RecordInvalid (constructor wants a record) with its class and message" do
+        data = { class_name: "ActiveRecord::RecordInvalid", message: "Validation failed: Name can't be blank",
+                 backtrace: [ "app/models/user.rb:10" ] }
+
+        expect { described_class.new.perform(data, context) }.to change(RailsErrorDashboard::ErrorLog, :count).by(1)
+        log = RailsErrorDashboard::ErrorLog.last
+        expect(log.error_type).to eq("ActiveRecord::RecordInvalid")
+        expect(log.message).to eq("Validation failed: Name can't be blank")
+      end
+
+      it "keeps a custom exception with a required keyword argument" do
+        stub_const("KeywordError", Class.new(StandardError) do
+          def initialize(message, code:)
+            @code = code
+            super(message)
+          end
+        end)
+        data = { class_name: "KeywordError", message: "failed with code", backtrace: [] }
+
+        expect { described_class.new.perform(data, context) }.to change(RailsErrorDashboard::ErrorLog, :count).by(1)
+        expect(RailsErrorDashboard::ErrorLog.last.error_type).to eq("KeywordError")
+      end
+
+      it "falls back to the constructor when the subclass builds its message from constructor state" do
+        stub_const("StatefulMessageError", Class.new(StandardError) do
+          def initialize(detail)
+            @detail = detail
+            super("stateful: #{detail}")
+          end
+
+          def message
+            "stateful: #{@detail.upcase}"
+          end
+        end)
+        data = { class_name: "StatefulMessageError", message: "boom", backtrace: [] }
+
+        expect { described_class.new.perform(data, context) }.to change(RailsErrorDashboard::ErrorLog, :count).by(1)
+        log = RailsErrorDashboard::ErrorLog.last
+        expect(log.error_type).to eq("StatefulMessageError")
+        expect(log.message).to eq("stateful: BOOM")
+      end
+    end
+
     it "preserves context data" do
       described_class.new.perform(exception_data, context)
       error_log = RailsErrorDashboard::ErrorLog.last

--- a/spec/jobs/rails_error_dashboard/baseline_calculation_job_spec.rb
+++ b/spec/jobs/rails_error_dashboard/baseline_calculation_job_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RailsErrorDashboard::BaselineCalculationJob, type: :job do
+  it "recalculates every baseline and returns the calculator's summary" do
+    log = create(:error_log, error_type: "NoMethodError", platform: "API", occurred_at: 1.day.ago)
+    create(:error_occurrence, error_log: log, occurred_at: 1.day.ago)
+
+    result = described_class.perform_now
+
+    expect(result[:calculated]).to be > 0
+    expect(RailsErrorDashboard::ErrorBaseline.where(error_type: "NoMethodError", platform: "API").count).to be > 0
+  end
+
+  it "re-raises so the queue's retry policy applies" do
+    allow(RailsErrorDashboard::Services::BaselineCalculator).to receive(:calculate_all_baselines).and_raise(RuntimeError, "db gone")
+    expect { described_class.perform_now }.to raise_error(RuntimeError, "db gone")
+  end
+end

--- a/spec/lib/rails_error_dashboard/error_reporter_spec.rb
+++ b/spec/lib/rails_error_dashboard/error_reporter_spec.rb
@@ -17,6 +17,31 @@ RSpec.describe RailsErrorDashboard::ErrorReporter do
     RailsErrorDashboard.reset_configuration!
   end
 
+  describe "context round trip through the subscriber path" do
+    before do
+      RailsErrorDashboard.configuration.async_logging = false
+      RailsErrorDashboard.configuration.enable_storm_protection = false
+    end
+
+    it "stores request/session IDs on the occurrence and honours an explicit environment" do
+      reporter.report(error, handled: false, severity: :error,
+        context: { request_id: "req-round-trip", session_id: "sess-round-trip", environment: "staging" })
+
+      occurrence = RailsErrorDashboard::ErrorOccurrence.last
+      expect(occurrence.request_id).to eq("req-round-trip")
+      expect(occurrence.session_id).to eq("sess-round-trip")
+      expect(occurrence.error_log.environment).to eq("staging")
+    end
+
+    it "stores the Rails request ID when the request comes from the middleware's Thread.current env" do
+      Thread.current[:rails_error_dashboard_request_env] = env.merge("action_dispatch.request_id" => "rails-req-77")
+
+      reporter.report(error, handled: false, severity: :error, context: {}, source: "application.action_dispatch")
+
+      expect(RailsErrorDashboard::ErrorOccurrence.last.request_id).to eq("rails-req-77")
+    end
+  end
+
   describe "#report" do
     context "when error from Rails internals inside an HTTP request" do
       before do

--- a/spec/queries/baseline_stats_spec.rb
+++ b/spec/queries/baseline_stats_spec.rb
@@ -75,6 +75,17 @@ RSpec.describe RailsErrorDashboard::Queries::BaselineStats do
       expect(counts[:weekly]).to eq(3)
     end
 
+    it "does not report another application's spike on a quiet application" do
+      create(:error_baseline, :hourly, error_type: error_type, platform: platform, mean: 0.1, std_dev: 0.1)
+      quiet = create(:application, name: "Quiet app")
+      busy = create(:application, name: "Busy app")
+      log = create(:error_log, application: busy, error_type: error_type, platform: platform)
+      5.times { create(:error_occurrence, error_log: log, occurred_at: Time.current) }
+
+      expect(stats.check_current_anomaly(application_id: quiet.id)[:anomaly]).to be false
+      expect(stats.check_current_anomaly(application_id: busy.id)[:anomaly]).to be true
+    end
+
     it "feeds those counts to the matching baseline" do
       create(:error_baseline, :hourly, error_type: error_type, platform: platform, mean: 0.1, std_dev: 0.1)
       log = create(:error_log, error_type: error_type, platform: platform)

--- a/spec/queries/baseline_stats_spec.rb
+++ b/spec/queries/baseline_stats_spec.rb
@@ -37,4 +37,53 @@ RSpec.describe RailsErrorDashboard::Queries::BaselineStats do
       expect(result[:std_devs_above]).to be_present
     end
   end
+  describe "#check_anomaly with per-unit counts" do
+    let(:stats) { described_class.new(error_type, platform) }
+
+    it "compares the current hour against the hourly baseline, not today's count" do
+      create(:error_baseline, :hourly, error_type: error_type, platform: platform, mean: 1.0, std_dev: 0.5)
+
+      quiet_hour_busy_day = stats.check_anomaly(hourly: 1, daily: 40, weekly: 200)
+      expect(quiet_hour_busy_day[:anomaly]).to be false
+      expect(quiet_hour_busy_day[:baseline_type]).to eq("hourly")
+      expect(quiet_hour_busy_day[:current_count]).to eq(1)
+
+      expect(stats.check_anomaly(hourly: 5, daily: 5, weekly: 5)[:anomaly]).to be true
+    end
+
+    it "falls through to the daily baseline with the daily count when there is no hourly baseline" do
+      create(:error_baseline, error_type: error_type, platform: platform, mean: 10.0, std_dev: 2.0) # daily
+
+      result = stats.check_anomaly(hourly: 100, daily: 10, weekly: 10)
+      expect(result[:baseline_type]).to eq("daily")
+      expect(result[:anomaly]).to be false
+    end
+  end
+
+  describe "#current_counts and #check_current_anomaly" do
+    let(:stats) { described_class.new(error_type, platform) }
+
+    it "counts occurrences of this error type in the current hour, day and week" do
+      log = create(:error_log, error_type: error_type, platform: platform)
+      create(:error_occurrence, error_log: log, occurred_at: Time.current)
+      create(:error_occurrence, error_log: log, occurred_at: Time.current.beginning_of_day + 1.second)
+      create(:error_occurrence, error_log: log, occurred_at: Time.current.beginning_of_week + 1.second)
+
+      counts = stats.current_counts
+      expect(counts[:hourly]).to be_between(1, 3)
+      expect(counts[:daily]).to be_between(2, 3)
+      expect(counts[:weekly]).to eq(3)
+    end
+
+    it "feeds those counts to the matching baseline" do
+      create(:error_baseline, :hourly, error_type: error_type, platform: platform, mean: 0.1, std_dev: 0.1)
+      log = create(:error_log, error_type: error_type, platform: platform)
+      4.times { create(:error_occurrence, error_log: log, occurred_at: Time.current) }
+
+      result = stats.check_current_anomaly(sensitivity: 2)
+      expect(result[:baseline_type]).to eq("hourly")
+      expect(result[:anomaly]).to be true
+      expect(result[:current_count]).to eq(4)
+    end
+  end
 end

--- a/spec/queries/rails_error_dashboard/queries/analytics_stats_spec.rb
+++ b/spec/queries/rails_error_dashboard/queries/analytics_stats_spec.rb
@@ -21,6 +21,18 @@ RSpec.describe RailsErrorDashboard::Queries::AnalyticsStats do
       )
     end
 
+    describe "application-scoped resolution rate" do
+      it "counts resolved errors from the same application only, so the rate stays within 0..100" do
+        target = create(:application, name: "Target scoped app")
+        other = create(:application, name: "Other scoped app")
+        create(:error_log, application: target, resolved: false, occurred_at: 1.day.ago)
+        create_list(:error_log, 3, application: other, resolved: true, status: "resolved", occurred_at: 1.day.ago)
+
+        expect(described_class.call(30, application_id: target.id)[:resolution_rate]).to eq(0)
+        expect(described_class.call(30, application_id: other.id)[:resolution_rate]).to eq(100.0)
+      end
+    end
+
     it "includes the number of days" do
       result = described_class.call(30)
 

--- a/spec/queries/release_timeline_spec.rb
+++ b/spec/queries/release_timeline_spec.rb
@@ -344,7 +344,7 @@ RSpec.describe RailsErrorDashboard::Queries::ReleaseTimeline do
       end
 
       it "handles very long version strings" do
-        long_version = "v" * 500
+        long_version = "v" * 200 # within the 255 clamp on every adapter
         versioned_error(application: app,
           app_version: long_version, occurred_at: 5.days.ago)
 

--- a/spec/queries/release_timeline_spec.rb
+++ b/spec/queries/release_timeline_spec.rb
@@ -5,6 +5,13 @@ require "rails_helper"
 RSpec.describe RailsErrorDashboard::Queries::ReleaseTimeline do
   let!(:app) { create(:application) }
 
+  # A captured error: the group row plus the occurrence that carries the
+  # release it happened under (the :with_version trait creates both, as
+  # LogError does for every capture).
+  def versioned_error(**attrs)
+    create(:error_log, :with_version, **attrs)
+  end
+
   describe ".call" do
     it "returns releases and summary keys" do
       result = described_class.call(30)
@@ -23,26 +30,26 @@ RSpec.describe RailsErrorDashboard::Queries::ReleaseTimeline do
     context "with versioned error data" do
       before do
         # v1.0.0: 3 errors, 2 unique types, oldest release
-        create(:error_log, :with_version, application: app,
+        versioned_error(application: app,
           app_version: "1.0.0", git_sha: "aaa111", error_type: "NoMethodError",
           error_hash: "hash_a", occurred_at: 20.days.ago)
-        create(:error_log, :with_version, application: app,
+        versioned_error(application: app,
           app_version: "1.0.0", git_sha: "aaa111", error_type: "NoMethodError",
           error_hash: "hash_a", occurred_at: 18.days.ago)
-        create(:error_log, :with_version, application: app,
+        versioned_error(application: app,
           app_version: "1.0.0", git_sha: "aaa111", error_type: "TypeError",
           error_hash: "hash_b", occurred_at: 15.days.ago)
 
         # v1.1.0: 2 errors, 1 new type + 1 from v1.0.0
-        create(:error_log, :with_version, application: app,
+        versioned_error(application: app,
           app_version: "1.1.0", git_sha: "bbb222", error_type: "NoMethodError",
           error_hash: "hash_a", occurred_at: 10.days.ago)
-        create(:error_log, :with_version, application: app,
+        versioned_error(application: app,
           app_version: "1.1.0", git_sha: "bbb222", error_type: "RuntimeError",
           error_hash: "hash_c", occurred_at: 8.days.ago)
 
         # v1.2.0: 1 error, 1 new type — most recent release
-        create(:error_log, :with_version, application: app,
+        versioned_error(application: app,
           app_version: "1.2.0", git_sha: "ccc333", error_type: "ArgumentError",
           error_hash: "hash_d", occurred_at: 2.days.ago)
       end
@@ -98,20 +105,50 @@ RSpec.describe RailsErrorDashboard::Queries::ReleaseTimeline do
       end
     end
 
+    context "recurrence after a deploy" do
+      it "attributes each occurrence to the release it happened under, not the group's first release" do
+        group = versioned_error(application: app, app_version: "1.0.0", git_sha: "aaa111",
+                                error_type: "NoMethodError", error_hash: "hash_a", occurred_at: 3.days.ago)
+        # The same group recurs after the 2.0.0 deploy: LogError increments the
+        # group (which keeps 1.0.0) and records an occurrence under 2.0.0.
+        create(:error_occurrence, error_log: group, occurred_at: 1.day.ago, app_version: "2.0.0", git_sha: "bbb222")
+        create(:error_occurrence, error_log: group, occurred_at: 1.hour.ago, app_version: "2.0.0", git_sha: "bbb222")
+        expect(group.reload.app_version).to eq("1.0.0")
+
+        releases = described_class.call(30, application_id: app.id)[:releases]
+        by_version = releases.to_h { |r| [ r[:version], r ] }
+
+        expect(by_version.keys).to contain_exactly("1.0.0", "2.0.0")
+        expect(by_version["1.0.0"][:total_errors]).to eq(1)
+        expect(by_version["2.0.0"][:total_errors]).to eq(2)
+        expect(by_version["2.0.0"][:git_shas]).to eq([ "bbb222" ])
+        expect(by_version["2.0.0"][:new_error_count]).to eq(0) # hash_a was new in 1.0.0
+        expect(releases.first[:version]).to eq("2.0.0")
+      end
+
+      it "falls back to counting group rows when occurrences do not carry a release" do
+        create(:error_log, :with_version, application: app, app_version: "1.0.0", occurred_at: 2.days.ago)
+        allow(RailsErrorDashboard::ErrorOccurrence).to receive(:column_names).and_return(%w[id error_log_id occurred_at])
+
+        releases = described_class.call(30, application_id: app.id)[:releases]
+        expect(releases.map { |r| [ r[:version], r[:total_errors] ] }).to eq([ [ "1.0.0", 1 ] ])
+      end
+    end
+
     context "new errors detection" do
       before do
         # hash_a first appears in v1.0.0
-        create(:error_log, :with_version, application: app,
+        versioned_error(application: app,
           app_version: "1.0.0", error_type: "NoMethodError",
           error_hash: "hash_a", occurred_at: 20.days.ago)
 
         # hash_a also appears in v1.1.0 — NOT new
-        create(:error_log, :with_version, application: app,
+        versioned_error(application: app,
           app_version: "1.1.0", error_type: "NoMethodError",
           error_hash: "hash_a", occurred_at: 10.days.ago)
 
         # hash_c first appears in v1.1.0 — NEW
-        create(:error_log, :with_version, application: app,
+        versioned_error(application: app,
           app_version: "1.1.0", error_type: "RuntimeError",
           error_hash: "hash_c", occurred_at: 8.days.ago)
       end
@@ -133,21 +170,21 @@ RSpec.describe RailsErrorDashboard::Queries::ReleaseTimeline do
       before do
         # v1.0.0: 2 errors (average)
         2.times do |i|
-          create(:error_log, :with_version, application: app,
+          versioned_error(application: app,
             app_version: "1.0.0", error_hash: "hash_#{i}",
             occurred_at: 20.days.ago)
         end
 
         # v1.1.0: 2 errors (average)
         2.times do |i|
-          create(:error_log, :with_version, application: app,
+          versioned_error(application: app,
             app_version: "1.1.0", error_hash: "hash_10#{i}",
             occurred_at: 10.days.ago)
         end
 
         # v1.2.0: 10 errors (5x average — red)
         10.times do |i|
-          create(:error_log, :with_version, application: app,
+          versioned_error(application: app,
             app_version: "1.2.0", error_hash: "hash_20#{i}",
             occurred_at: 2.days.ago)
         end
@@ -170,13 +207,13 @@ RSpec.describe RailsErrorDashboard::Queries::ReleaseTimeline do
     context "release comparison (delta)" do
       before do
         3.times do |i|
-          create(:error_log, :with_version, application: app,
+          versioned_error(application: app,
             app_version: "1.0.0", error_hash: "hash_#{i}",
             occurred_at: 20.days.ago)
         end
 
         5.times do |i|
-          create(:error_log, :with_version, application: app,
+          versioned_error(application: app,
             app_version: "1.1.0", error_hash: "hash_10#{i}",
             occurred_at: 10.days.ago)
         end
@@ -203,9 +240,9 @@ RSpec.describe RailsErrorDashboard::Queries::ReleaseTimeline do
 
     context "filters" do
       it "respects the days parameter" do
-        create(:error_log, :with_version, application: app,
+        versioned_error(application: app,
           app_version: "1.0.0", occurred_at: 40.days.ago)
-        create(:error_log, :with_version, application: app,
+        versioned_error(application: app,
           app_version: "1.1.0", occurred_at: 5.days.ago)
 
         result = described_class.call(30, application_id: app.id)
@@ -216,9 +253,9 @@ RSpec.describe RailsErrorDashboard::Queries::ReleaseTimeline do
 
       it "filters by application_id" do
         other_app = create(:application, name: "other-app")
-        create(:error_log, :with_version, application: app,
+        versioned_error(application: app,
           app_version: "1.0.0", occurred_at: 5.days.ago)
-        create(:error_log, :with_version, application: other_app,
+        versioned_error(application: other_app,
           app_version: "2.0.0", occurred_at: 5.days.ago)
 
         result = described_class.call(30, application_id: app.id)
@@ -230,7 +267,7 @@ RSpec.describe RailsErrorDashboard::Queries::ReleaseTimeline do
 
     context "edge cases" do
       it "handles a single release" do
-        create(:error_log, :with_version, application: app,
+        versioned_error(application: app,
           app_version: "1.0.0", error_hash: "hash_a", occurred_at: 5.days.ago)
 
         result = described_class.call(30, application_id: app.id)
@@ -242,9 +279,9 @@ RSpec.describe RailsErrorDashboard::Queries::ReleaseTimeline do
       end
 
       it "counts all distinct hashes as new when all errors are the same version" do
-        create(:error_log, :with_version, application: app,
+        versioned_error(application: app,
           app_version: "1.0.0", error_hash: "hash_a", occurred_at: 5.days.ago)
-        create(:error_log, :with_version, application: app,
+        versioned_error(application: app,
           app_version: "1.0.0", error_hash: "hash_b", occurred_at: 4.days.ago)
 
         result = described_class.call(30, application_id: app.id)
@@ -253,7 +290,7 @@ RSpec.describe RailsErrorDashboard::Queries::ReleaseTimeline do
 
       it "excludes errors with empty string app_version" do
         create(:error_log, application: app, app_version: "", occurred_at: 5.days.ago)
-        create(:error_log, :with_version, application: app,
+        versioned_error(application: app,
           app_version: "1.0.0", occurred_at: 5.days.ago)
 
         result = described_class.call(30, application_id: app.id)
@@ -262,7 +299,7 @@ RSpec.describe RailsErrorDashboard::Queries::ReleaseTimeline do
       end
 
       it "handles days=0 without error" do
-        create(:error_log, :with_version, application: app,
+        versioned_error(application: app,
           app_version: "1.0.0", occurred_at: Time.current)
 
         result = described_class.call(0, application_id: app.id)
@@ -278,11 +315,11 @@ RSpec.describe RailsErrorDashboard::Queries::ReleaseTimeline do
 
       it "returns zero delta when consecutive releases have equal error counts" do
         2.times do |i|
-          create(:error_log, :with_version, application: app,
+          versioned_error(application: app,
             app_version: "1.0.0", error_hash: "hash_#{i}", occurred_at: 20.days.ago)
         end
         2.times do |i|
-          create(:error_log, :with_version, application: app,
+          versioned_error(application: app,
             app_version: "1.1.0", error_hash: "hash_10#{i}", occurred_at: 10.days.ago)
         end
 
@@ -294,10 +331,10 @@ RSpec.describe RailsErrorDashboard::Queries::ReleaseTimeline do
 
       it "assigns yellow stability for releases between 1x and 2x average" do
         # v1.0.0: 1 error, v1.1.0: 3 errors — avg = 2, v1.1.0 is 1.5x avg → yellow
-        create(:error_log, :with_version, application: app,
+        versioned_error(application: app,
           app_version: "1.0.0", error_hash: "hash_a", occurred_at: 20.days.ago)
         3.times do |i|
-          create(:error_log, :with_version, application: app,
+          versioned_error(application: app,
             app_version: "1.1.0", error_hash: "hash_1#{i}", occurred_at: 10.days.ago)
         end
 
@@ -308,7 +345,7 @@ RSpec.describe RailsErrorDashboard::Queries::ReleaseTimeline do
 
       it "handles very long version strings" do
         long_version = "v" * 500
-        create(:error_log, :with_version, application: app,
+        versioned_error(application: app,
           app_version: long_version, occurred_at: 5.days.ago)
 
         result = described_class.call(30, application_id: app.id)

--- a/spec/services/baseline_calculator_spec.rb
+++ b/spec/services/baseline_calculator_spec.rb
@@ -71,6 +71,30 @@ RSpec.describe RailsErrorDashboard::Services::BaselineCalculator do
       expect(daily.count).to eq(7)
     end
 
+    it "buckets weeks on the same day Rails does, so a Sunday and a Monday event land in different weeks" do
+      Time.use_zone("UTC") do
+        log = create(:error_log, error_type: error_type, platform: platform, occurred_at: 1.day.ago)
+        create(:error_occurrence, error_log: log, occurred_at: Time.zone.parse("2026-08-09 12:00")) # Sunday
+        create(:error_occurrence, error_log: log, occurred_at: Time.zone.parse("2026-08-10 12:00")) # Monday
+        start_at = Time.zone.parse("2026-08-03 00:00") # a Monday, as Rails' beginning_of_week gives
+        end_at = Time.zone.parse("2026-08-17 00:00")
+
+        counts = described_class.new.send(:bucket_counts, error_type, platform, :week, start_at, end_at)
+        expect(counts).to eq([ 1, 1 ])
+      end
+    end
+
+    it "scopes the counting relation to one application when asked" do
+      quiet = create(:application, name: "Quiet baseline app")
+      busy = create(:application, name: "Busy baseline app")
+      log = create(:error_log, application: busy, error_type: error_type, platform: platform)
+      3.times { create(:error_occurrence, error_log: log, occurred_at: Time.current) }
+
+      expect(described_class.counting_relation(error_type, platform, application_id: quiet.id).count).to eq(0)
+      expect(described_class.counting_relation(error_type, platform, application_id: busy.id).count).to eq(3)
+      expect(described_class.counting_relation(error_type, platform).count).to eq(3)
+    end
+
     it "counts occurrences, not group rows" do
       log = create(:error_log, error_type: error_type, platform: platform, occurred_at: 1.day.ago)
       3.times { create(:error_occurrence, error_log: log, occurred_at: 1.day.ago.noon) }

--- a/spec/services/baseline_calculator_spec.rb
+++ b/spec/services/baseline_calculator_spec.rb
@@ -8,9 +8,11 @@ RSpec.describe RailsErrorDashboard::Services::BaselineCalculator do
     let(:platform) { "iOS" }
 
     before do
-      # Create errors over the past weeks
+      # Create errors over the past weeks — each capture is a group row plus
+      # the occurrence the calculator actually counts
       30.times do |i|
-        create(:error_log, error_type: error_type, platform: platform, occurred_at: i.days.ago)
+        log = create(:error_log, error_type: error_type, platform: platform, occurred_at: i.days.ago)
+        create(:error_occurrence, error_log: log, occurred_at: i.days.ago)
       end
     end
 
@@ -42,10 +44,57 @@ RSpec.describe RailsErrorDashboard::Services::BaselineCalculator do
     end
   end
 
+  describe "sampling unit" do
+    let(:error_type) { "ReviewBaselineError" }
+    let(:platform) { "API" }
+
+    it "treats each calendar hour as one sample, zero hours included" do
+      log = create(:error_log, error_type: error_type, platform: platform, occurred_at: 1.day.ago)
+      7.times do |i|
+        create(:error_occurrence, error_log: log, occurred_at: (i + 1).days.ago.beginning_of_day + 12.hours)
+      end
+
+      hourly = described_class.new.send(:calculate_hourly_baseline, error_type, platform)
+
+      expect(hourly.sample_size).to eq(4 * 7 * 24)   # every hour of the four-week lookback
+      expect(hourly.count).to eq(7)
+      expect(hourly.mean).to eq((7.0 / (4 * 7 * 24)).round(2))
+    end
+
+    it "treats each calendar day as one sample" do
+      log = create(:error_log, error_type: error_type, platform: platform, occurred_at: 1.day.ago)
+      7.times { |i| create(:error_occurrence, error_log: log, occurred_at: (i + 1).days.ago.noon) }
+
+      daily = described_class.new.send(:calculate_daily_baseline, error_type, platform)
+
+      expect(daily.sample_size).to eq(12 * 7)
+      expect(daily.count).to eq(7)
+    end
+
+    it "counts occurrences, not group rows" do
+      log = create(:error_log, error_type: error_type, platform: platform, occurred_at: 1.day.ago)
+      3.times { create(:error_occurrence, error_log: log, occurred_at: 1.day.ago.noon) }
+
+      daily = described_class.new.send(:calculate_daily_baseline, error_type, platform)
+      expect(daily.count).to eq(3)
+    end
+
+    it "returns nil when there were no events in the lookback" do
+      expect(described_class.new.send(:calculate_hourly_baseline, "NeverSeen", platform)).to be_nil
+    end
+
+    it "does not embed adapter-specific SQL" do
+      source = File.read(RailsErrorDashboard::Engine.root.join("lib/rails_error_dashboard/services/baseline_calculator.rb"))
+      expect(source).not_to include("strftime")
+    end
+  end
+
   describe "#calculate_all_baselines" do
     it "calculates baselines for all error type/platform combinations" do
-      create(:error_log, error_type: "NoMethodError", platform: "iOS", occurred_at: 1.day.ago)
-      create(:error_log, error_type: "ArgumentError", platform: "Android", occurred_at: 1.day.ago)
+      a = create(:error_log, error_type: "NoMethodError", platform: "iOS", occurred_at: 1.day.ago)
+      b = create(:error_log, error_type: "ArgumentError", platform: "Android", occurred_at: 1.day.ago)
+      create(:error_occurrence, error_log: a, occurred_at: 1.day.ago)
+      create(:error_occurrence, error_log: b, occurred_at: 1.day.ago)
 
       result = described_class.calculate_all_baselines
 

--- a/spec/services/error_hash_generator_spec.rb
+++ b/spec/services/error_hash_generator_spec.rb
@@ -160,6 +160,20 @@ RSpec.describe RailsErrorDashboard::Services::ErrorHashGenerator do
     end
   end
 
+  describe ".normalize_message" do
+    it "hashes only the first HASH_MESSAGE_LIMIT raw characters, so long messages keep one identity" do
+      prefix = "a" * described_class::HASH_MESSAGE_LIMIT
+      expect(described_class.normalize_message(prefix + " one")).to eq(described_class.normalize_message(prefix + " two"))
+    end
+
+    it "truncates before normalizing, matching what the storm gate stores" do
+      raw = ("word " * 120) + "id=12345"
+      expect(described_class.normalize_message(raw)).to eq(
+        described_class.normalize_message(raw[0, described_class::HASH_MESSAGE_LIMIT])
+      )
+    end
+  end
+
   describe ".extract_app_frame_from_locations" do
     it "extracts the first non-gem frame from backtrace_locations" do
       exception = begin

--- a/spec/services/local_variable_capturer_spec.rb
+++ b/spec/services/local_variable_capturer_spec.rb
@@ -91,6 +91,92 @@ RSpec.describe RailsErrorDashboard::Services::LocalVariableCapturer do
     end
   end
 
+  describe "raise-time snapshots" do
+    before do
+      RailsErrorDashboard.configuration.enable_local_variables = true
+      RailsErrorDashboard.configuration.enable_instance_variables = true
+      described_class.enable!
+    end
+    after { RailsErrorDashboard.reset_configuration! }
+
+    # eval with an app-looking path so the capturer does not skip the frame as gem/spec code
+    def raise_in_app(code)
+      eval(code, TOPLEVEL_BINDING, "/app/services/snapshot_probe.rb", 1) # rubocop:disable Security/Eval
+    end
+
+    it "keeps the hash values from the moment of the raise, not after an ensure block mutated them" do
+      exception = raise_in_app(<<~RUBY)
+        begin
+          state = { "phase" => "at raise" }
+          begin
+            raise StandardError, "snapshot probe"
+          ensure
+            state["phase"] = "after unwind"
+          end
+        rescue StandardError => caught
+          caught
+        end
+      RUBY
+
+      expect(described_class.extract(exception)[:state]["phase"]).to eq("at raise")
+    end
+
+    it "keeps string and array values from the moment of the raise" do
+      exception = raise_in_app(<<~RUBY)
+        begin
+          label = +"pending"
+          items = [ 1, 2 ]
+          begin
+            raise StandardError, "snapshot probe"
+          ensure
+            label << " (cleaned up)"
+            items << 3
+          end
+        rescue StandardError => caught
+          caught
+        end
+      RUBY
+
+      locals = described_class.extract(exception)
+      expect(locals[:label]).to eq("pending")
+      expect(locals[:items]).to eq([ 1, 2 ])
+    end
+
+    it "snapshots instance variables the same way" do
+      # The class must live at an app-looking path too: the raise happens
+      # inside #run, and a frame in this spec file is skipped as gem code.
+      exception = raise_in_app(<<~RUBY)
+        snapshot_probe_service = Class.new do
+          def run
+            @status = { "conn" => "open" }
+            raise StandardError, "snapshot probe"
+          ensure
+            @status["conn"] = "closed"
+          end
+        end
+        begin
+          snapshot_probe_service.new.run
+        rescue StandardError => caught
+          caught
+        end
+      RUBY
+
+      ivars = described_class.extract_instance_vars(exception)
+      expect(ivars[:@status]["conn"]).to eq("open")
+    end
+
+    it "bounds the copy by the serializer's limits so a huge collection is not duplicated" do
+      RailsErrorDashboard.configuration.local_variable_max_array_items = 3
+      expect(described_class.send(:snapshot_value, (1..1000).to_a).size).to eq(4)
+      expect(described_class.send(:snapshot_value, "x" * 5000).size).to eq(201)
+    end
+
+    it "leaves other objects as references" do
+      obj = Object.new
+      expect(described_class.send(:snapshot_value, obj)).to equal(obj)
+    end
+  end
+
   describe ".extract" do
     it "returns nil for nil input" do
       expect(described_class.extract(nil)).to be_nil

--- a/spec/services/storm_protection/count_buffer_spec.rb
+++ b/spec/services/storm_protection/count_buffer_spec.rb
@@ -78,6 +78,15 @@ RSpec.describe RailsErrorDashboard::Services::StormProtection::CountBuffer do
       expect(entry["last_seen_at"]).to be_present
     end
 
+    it "carries an explicit environment through snapshot and restore" do
+      buffer.record("key-staging", parts.merge(environment: "staging"))
+      lost = buffer.snapshot!
+      expect(lost[:entries].first["environment"]).to eq("staging")
+
+      buffer.restore(lost[:entries], 0)
+      expect(buffer.snapshot![:entries].first["environment"]).to eq("staging")
+    end
+
     it "carries the custom hash when present" do
       buffer.record("custom123", parts.merge(custom_hash: "custom123"))
       expect(buffer.snapshot![:entries].first["custom_hash"]).to eq("custom123")

--- a/spec/services/storm_protection/count_buffer_spec.rb
+++ b/spec/services/storm_protection/count_buffer_spec.rb
@@ -17,6 +17,42 @@ RSpec.describe RailsErrorDashboard::Services::StormProtection::CountBuffer do
 
   after { RailsErrorDashboard.reset_configuration! }
 
+  describe "#restore" do
+    it "merges a failed batch back so the next flush carries it" do
+      3.times { buffer.record("key1", parts) }
+      lost = buffer.snapshot!
+      expect(buffer.any?).to be false
+
+      buffer.restore(lost[:entries], lost[:overflow])
+      buffer.record("key1", parts)
+
+      entry = buffer.snapshot![:entries].first
+      expect(entry["count"]).to eq(4)
+      expect(entry["error_class"]).to eq("NoMethodError")
+      expect(Time.zone.parse(entry["first_seen_at"])).to be <= Time.zone.parse(lost[:entries].first["first_seen_at"]) + 1
+    end
+
+    it "restores the overflow bucket and spills restored fingerprints past the cap into it" do
+      RailsErrorDashboard.configuration.storm_max_tracked_fingerprints = 1
+      buffer.record("key1", parts)
+      buffer.record("key2", parts.merge(error_class: "TypeError")) # overflow: 1
+      lost = buffer.snapshot!
+      expect(lost[:overflow]).to eq(1)
+
+      buffer.record("key3", parts.merge(error_class: "IOError")) # occupies the single slot
+      buffer.restore(lost[:entries], lost[:overflow])
+
+      snapshot = buffer.snapshot!
+      expect(snapshot[:entries].map { |e| e["count"] }).to eq([ 1 ])
+      expect(snapshot[:overflow]).to eq(2) # the restored overflow plus key1, which no longer fits
+    end
+
+    it "ignores corrupt entries" do
+      expect { buffer.restore([ 42, nil, { "count" => 0 } ], 0) }.not_to raise_error
+      expect(buffer.any?).to be false
+    end
+  end
+
   describe "#record + #snapshot!" do
     it "accumulates exact counts per gate key" do
       5.times { buffer.record("key1", parts) }
@@ -45,6 +81,41 @@ RSpec.describe RailsErrorDashboard::Services::StormProtection::CountBuffer do
     it "carries the custom hash when present" do
       buffer.record("custom123", parts.merge(custom_hash: "custom123"))
       expect(buffer.snapshot![:entries].first["custom_hash"]).to eq("custom123")
+    end
+
+    it "never loses a writer that read the map just before a snapshot swap" do
+      buffer.record("key1", parts)
+      reference = buffer.instance_variable_get(:@map_ref)
+      entered = Queue.new
+      resume = Queue.new
+      original_get = reference.method(:get)
+      reference.define_singleton_method(:get) do
+        map = original_get.call
+        if Thread.current[:racing_writer]
+          entered << true
+          resume.pop
+        end
+        map
+      end
+
+      writer = Thread.new do
+        Thread.current[:racing_writer] = true
+        buffer.record("key1", parts)
+      end
+      entered.pop # the writer holds the old map reference and is mid-record
+
+      snapshots = []
+      snapshotter = Thread.new { snapshots << buffer.snapshot! }
+      sleep 0.05
+      expect(snapshotter.alive?).to be(true) # the swap waits for the in-flight writer
+
+      resume << true
+      writer.join
+      snapshotter.join
+      snapshots << buffer.snapshot!
+
+      total = snapshots.flat_map { |s| s[:entries] }.sum { |e| e["count"] }
+      expect(total).to eq(2)
     end
 
     it "swap is atomic: post-snapshot records land in the fresh buffer" do

--- a/spec/services/storm_protection/gate_spec.rb
+++ b/spec/services/storm_protection/gate_spec.rb
@@ -14,6 +14,29 @@ RSpec.describe RailsErrorDashboard::Services::StormProtection::Gate do
     error
   end
 
+  describe ".maybe_flush! when the queue is unavailable" do
+    before { gate.reset! }
+    after { gate.reset! }
+
+    it "retains the batch and the episode, then hands both off on the next interval" do
+      gate.count_buffer.record("key", gate.send(:gate_parts, boom, {}))
+      gate.instance_variable_set(:@last_flush, 0)
+      allow(RailsErrorDashboard::StormFlushJob).to receive(:perform_later).and_raise(IOError, "queue unavailable")
+
+      expect { gate.send(:maybe_flush!) }.not_to raise_error
+      expect(RailsErrorDashboard::StormFlushJob).to have_received(:perform_later).once
+      expect(gate.count_buffer.any?).to be(true)
+
+      handed_off = nil
+      allow(RailsErrorDashboard::StormFlushJob).to receive(:perform_later) { |**kwargs| handed_off = kwargs }
+      gate.instance_variable_set(:@last_flush, 0)
+      gate.send(:maybe_flush!)
+
+      expect(handed_off[:entries].sum { |e| e["count"] }).to eq(1)
+      expect(gate.count_buffer.any?).to be(false)
+    end
+  end
+
   describe ".admit!" do
     it "returns :full when storm protection is disabled" do
       RailsErrorDashboard.configuration.enable_storm_protection = false

--- a/spec/services/storm_protection/gate_spec.rb
+++ b/spec/services/storm_protection/gate_spec.rb
@@ -28,7 +28,10 @@ RSpec.describe RailsErrorDashboard::Services::StormProtection::Gate do
       expect(gate.count_buffer.any?).to be(true)
     end
 
-    it "retains the batch when the real queue adapter raises ActiveJob::EnqueueError (which Active Job swallows)" do
+    it "retains the batch when the real queue adapter raises ActiveJob::EnqueueError" do
+      # Rails 7.2+ swallows EnqueueError inside perform_later and returns
+      # false; 7.0/7.1 let it propagate. The gate must retain the batch
+      # either way, so no assumption about perform_later's return here.
       adapter = Object.new
       adapter.define_singleton_method(:enqueue) { |_job| raise ActiveJob::EnqueueError, "queue store down" }
       adapter.define_singleton_method(:enqueue_at) { |*_| raise ActiveJob::EnqueueError, "queue store down" }
@@ -37,7 +40,6 @@ RSpec.describe RailsErrorDashboard::Services::StormProtection::Gate do
       original = RailsErrorDashboard::StormFlushJob.queue_adapter
       begin
         RailsErrorDashboard::StormFlushJob.queue_adapter = adapter
-        expect(RailsErrorDashboard::StormFlushJob.perform_later(entries: [])).to be(false)
 
         gate.count_buffer.record("key", gate.send(:gate_parts, boom, {}))
         gate.instance_variable_set(:@last_flush, 0)

--- a/spec/services/storm_protection/gate_spec.rb
+++ b/spec/services/storm_protection/gate_spec.rb
@@ -37,9 +37,15 @@ RSpec.describe RailsErrorDashboard::Services::StormProtection::Gate do
       adapter.define_singleton_method(:enqueue_at) { |*_| raise ActiveJob::EnqueueError, "queue store down" }
       # Rails 7.x asks the adapter this before enqueuing; Rails 8 does not.
       adapter.define_singleton_method(:enqueue_after_transaction_commit?) { false }
-      original = RailsErrorDashboard::StormFlushJob.queue_adapter
+      job_class = RailsErrorDashboard::StormFlushJob
+      original = job_class.queue_adapter
+      # Rails 7.0/7.1 keep answering with the test adapter while one is
+      # enabled, whatever queue_adapter= was given; 7.2+ honour the
+      # assignment. Disable it for the duration so the fake is really used.
+      test_adapter = job_class.respond_to?(:_test_adapter) ? job_class._test_adapter : nil
       begin
-        RailsErrorDashboard::StormFlushJob.queue_adapter = adapter
+        job_class.disable_test_adapter if job_class.respond_to?(:disable_test_adapter)
+        job_class.queue_adapter = adapter
 
         gate.count_buffer.record("key", gate.send(:gate_parts, boom, {}))
         gate.instance_variable_set(:@last_flush, 0)
@@ -47,7 +53,8 @@ RSpec.describe RailsErrorDashboard::Services::StormProtection::Gate do
 
         expect(gate.count_buffer.any?).to be(true)
       ensure
-        RailsErrorDashboard::StormFlushJob.queue_adapter = original
+        job_class.queue_adapter = original
+        job_class.enable_test_adapter(test_adapter) if test_adapter && job_class.respond_to?(:enable_test_adapter)
       end
     end
 

--- a/spec/services/storm_protection/gate_spec.rb
+++ b/spec/services/storm_protection/gate_spec.rb
@@ -18,6 +18,35 @@ RSpec.describe RailsErrorDashboard::Services::StormProtection::Gate do
     before { gate.reset! }
     after { gate.reset! }
 
+    it "retains the batch when perform_later returns false instead of raising" do
+      gate.count_buffer.record("key", gate.send(:gate_parts, boom, {}))
+      gate.instance_variable_set(:@last_flush, 0)
+      allow(RailsErrorDashboard::StormFlushJob).to receive(:perform_later).and_return(false)
+
+      gate.send(:maybe_flush!)
+
+      expect(gate.count_buffer.any?).to be(true)
+    end
+
+    it "retains the batch when the real queue adapter raises ActiveJob::EnqueueError (which Active Job swallows)" do
+      adapter = Object.new
+      adapter.define_singleton_method(:enqueue) { |_job| raise ActiveJob::EnqueueError, "queue store down" }
+      adapter.define_singleton_method(:enqueue_at) { |*_| raise ActiveJob::EnqueueError, "queue store down" }
+      original = RailsErrorDashboard::StormFlushJob.queue_adapter
+      begin
+        RailsErrorDashboard::StormFlushJob.queue_adapter = adapter
+        expect(RailsErrorDashboard::StormFlushJob.perform_later(entries: [])).to be(false)
+
+        gate.count_buffer.record("key", gate.send(:gate_parts, boom, {}))
+        gate.instance_variable_set(:@last_flush, 0)
+        gate.send(:maybe_flush!)
+
+        expect(gate.count_buffer.any?).to be(true)
+      ensure
+        RailsErrorDashboard::StormFlushJob.queue_adapter = original
+      end
+    end
+
     it "retains the batch and the episode, then hands both off on the next interval" do
       gate.count_buffer.record("key", gate.send(:gate_parts, boom, {}))
       gate.instance_variable_set(:@last_flush, 0)

--- a/spec/services/storm_protection/gate_spec.rb
+++ b/spec/services/storm_protection/gate_spec.rb
@@ -66,6 +66,18 @@ RSpec.describe RailsErrorDashboard::Services::StormProtection::Gate do
     end
   end
 
+  describe ".gate_key" do
+    it "separates the same error in different environments so they reconcile onto their own rows" do
+      staging = gate.send(:gate_parts, boom, { environment: "staging" })
+      production = gate.send(:gate_parts, boom, { environment: "production" })
+      implicit = gate.send(:gate_parts, boom, {})
+
+      expect(gate.send(:gate_key, staging)).not_to eq(gate.send(:gate_key, production))
+      expect(gate.send(:gate_key, implicit)).not_to eq(gate.send(:gate_key, staging))
+      expect(implicit[:environment]).to be_nil
+    end
+  end
+
   describe ".admit!" do
     it "returns :full when storm protection is disabled" do
       RailsErrorDashboard.configuration.enable_storm_protection = false

--- a/spec/services/storm_protection/gate_spec.rb
+++ b/spec/services/storm_protection/gate_spec.rb
@@ -32,6 +32,8 @@ RSpec.describe RailsErrorDashboard::Services::StormProtection::Gate do
       adapter = Object.new
       adapter.define_singleton_method(:enqueue) { |_job| raise ActiveJob::EnqueueError, "queue store down" }
       adapter.define_singleton_method(:enqueue_at) { |*_| raise ActiveJob::EnqueueError, "queue store down" }
+      # Rails 7.x asks the adapter this before enqueuing; Rails 8 does not.
+      adapter.define_singleton_method(:enqueue_after_transaction_commit?) { false }
       original = RailsErrorDashboard::StormFlushJob.queue_adapter
       begin
         RailsErrorDashboard::StormFlushJob.queue_adapter = adapter

--- a/spec/services/system_health_snapshot_spec.rb
+++ b/spec/services/system_health_snapshot_spec.rb
@@ -47,6 +47,57 @@ RSpec.describe RailsErrorDashboard::Services::SystemHealthSnapshot do
       expect(counter.calls).to eq(10)
     end
 
+    it "runs one refresh for a burst of cold-cache readers; the others get nil rather than a second refresh" do
+      RailsErrorDashboard.configuration.system_health_queue_stats_cache_seconds = 10
+      started = Queue.new
+      finish = Queue.new
+      collections = Concurrent::AtomicFixnum.new(0)
+      instances = Array.new(8) do
+        described_class.new.tap do |instance|
+          instance.define_singleton_method(:collect_job_queue_stats) do
+            collections.increment
+            started << true
+            finish.pop
+            { adapter: "synthetic", ready: 0 }
+          end
+        end
+      end
+
+      threads = instances.map { |i| Thread.new { i.send(:job_queue_stats) } }
+      Timeout.timeout(5) { started.pop } # exactly one collector is inside
+      sleep 0.05
+      finish << true
+      results = threads.map(&:value)
+
+      expect(collections.value).to eq(1)
+      expect(results.count { |r| r&.dig(:adapter) == "synthetic" }).to eq(1)
+      expect(results.count(&:nil?)).to eq(7)
+    end
+
+    it "caches a failed collection for the interval instead of retrying on every error" do
+      RailsErrorDashboard::Services::SystemHealthSnapshot.reset_queue_stats_cache!
+      RailsErrorDashboard.configuration.system_health_queue_stats_cache_seconds = 10
+      calls = 0
+      instance = described_class.new
+      instance.define_singleton_method(:collect_job_queue_stats) { calls += 1; nil }
+
+      3.times { expect(instance.send(:job_queue_stats)).to be_nil }
+      expect(calls).to eq(1)
+    end
+
+    it "marks a stale entry served while a refresh is in flight" do
+      RailsErrorDashboard.configuration.system_health_queue_stats_cache_seconds = 10
+      described_class.queue_stats_cache.set({ at: Process.clock_gettime(Process::CLOCK_MONOTONIC) - 60, stats: { adapter: "old" } })
+      described_class.queue_stats_refresh_lock.lock
+      begin
+        served = described_class.new.send(:job_queue_stats)
+        expect(served[:adapter]).to eq("old")
+        expect(served[:stale]).to be(true)
+      ensure
+        described_class.queue_stats_refresh_lock.unlock
+      end
+    end
+
     it "skips the queue counts entirely when system_health_queue_stats is off" do
       RailsErrorDashboard.configuration.system_health_queue_stats = false
       expect(described_class.capture[:job_queue]).to be_nil

--- a/spec/services/system_health_snapshot_spec.rb
+++ b/spec/services/system_health_snapshot_spec.rb
@@ -3,6 +3,57 @@
 require "rails_helper"
 
 RSpec.describe RailsErrorDashboard::Services::SystemHealthSnapshot do
+  before { described_class.reset_queue_stats_cache! }
+  after { RailsErrorDashboard.reset_configuration! }
+
+  describe "job-queue count caching" do
+    let(:counter) { Class.new { @calls = 0; class << self; attr_accessor :calls; end } }
+
+    before do
+      stub_const("SolidQueue", Module.new)
+      klass = counter
+      %w[ReadyExecution ScheduledExecution ClaimedExecution FailedExecution BlockedExecution].each do |name|
+        stub_const("SolidQueue::#{name}", Class.new { define_singleton_method(:count) { klass.calls += 1; 0 } })
+      end
+    end
+
+    it "runs the queue counts once per cache interval, not once per error" do
+      RailsErrorDashboard.configuration.system_health_queue_stats_cache_seconds = 10
+
+      first = described_class.capture
+      second = described_class.capture
+
+      expect(counter.calls).to eq(5)
+      expect(first[:job_queue][:adapter]).to eq("solid_queue")
+      expect(second[:job_queue][:adapter]).to eq("solid_queue")
+      expect(second[:job_queue][:cached_age_seconds]).to be_a(Float)
+      expect(first[:job_queue]).not_to have_key(:cached_age_seconds)
+    end
+
+    it "re-runs the counts once the interval has passed" do
+      RailsErrorDashboard.configuration.system_health_queue_stats_cache_seconds = 10
+      described_class.capture
+      stale = described_class.queue_stats_cache.get
+      described_class.queue_stats_cache.set(stale.merge(at: stale[:at] - 11))
+
+      described_class.capture
+      expect(counter.calls).to eq(10)
+    end
+
+    it "runs the counts every time when caching is set to 0" do
+      RailsErrorDashboard.configuration.system_health_queue_stats_cache_seconds = 0
+      described_class.capture
+      described_class.capture
+      expect(counter.calls).to eq(10)
+    end
+
+    it "skips the queue counts entirely when system_health_queue_stats is off" do
+      RailsErrorDashboard.configuration.system_health_queue_stats = false
+      expect(described_class.capture[:job_queue]).to be_nil
+      expect(counter.calls).to eq(0)
+    end
+  end
+
   describe ".capture" do
     subject(:snapshot) { described_class.capture }
 

--- a/spec/system/query_integration_spec.rb
+++ b/spec/system/query_integration_spec.rb
@@ -869,9 +869,11 @@ RSpec.describe "Query Integration", type: :system do
       # Create errors so BaselineCalculator has data to work with
       error = create(:error_log, error_type: "Phase12CalcError", platform: "Web",
                                  occurred_at: 1.day.ago)
+      create(:error_occurrence, error_log: error, occurred_at: 1.day.ago)
       3.times do |i|
-        create(:error_log, error_type: "Phase12CalcError", platform: "Web",
-                           occurred_at: (i + 2).days.ago)
+        log = create(:error_log, error_type: "Phase12CalcError", platform: "Web",
+                                 occurred_at: (i + 2).days.ago)
+        create(:error_occurrence, error_log: log, occurred_at: (i + 2).days.ago)
       end
 
       # Run the calculator — it should delegate to UpsertBaseline

--- a/spec/value_objects/error_context_spec.rb
+++ b/spec/value_objects/error_context_spec.rb
@@ -312,8 +312,24 @@ RSpec.describe RailsErrorDashboard::ValueObjects::ErrorContext do
       expect(result).to be_a(Hash)
       expect(result.keys).to contain_exactly(
         :user_id, :request_url, :request_params, :user_agent, :ip_address, :platform,
-        :controller_name, :action_name, :http_method, :hostname, :content_type, :request_duration_ms
+        :controller_name, :action_name, :request_id, :session_id, :http_method, :hostname,
+        :content_type, :request_duration_ms, :environment
       )
+    end
+
+    it "survives a round trip: a context rebuilt from to_h keeps request/session IDs and environment" do
+      original = described_class.new(
+        { request_id: "req-42", session_id: "sess-42", environment: "staging", user_id: 1 }
+      )
+      rebuilt = described_class.new(original.to_h)
+
+      expect(rebuilt.request_id).to eq("req-42")
+      expect(rebuilt.session_id).to eq("sess-42")
+      expect(rebuilt.environment).to eq("staging")
+    end
+
+    it "leaves environment nil when the caller gave none, so LogError resolves it from configuration" do
+      expect(described_class.new({ user_id: 1 }).to_h[:environment]).to be_nil
     end
   end
 end


### PR DESCRIPTION
## Summary

Eighteen `fix:` commits plus one docs commit addressing an independent review of 0.11.5 and its follow-up round. Every finding has a code fix and a spec that reproduces the defect and asserts the corrected behaviour. All commits are patch-level, so release-please should cut **0.11.6**.

### Storm protection
- Redact exemplar messages before storm persistence (first-seen rows and the storm ledger bypassed `SensitiveDataFilter`)
- Reconcile counted events onto **one** group row using the same 24 h window as the normal path (an error open for N days was multiplied N times)
- Hash the same 500-char message prefix on both capture paths (long-message errors changed identity when the breaker changed state)
- Keep exact counts through snapshot races (read/write lock) and failed flush enqueues, including Active Job returning `false` instead of raising
- Carry an explicit environment through count-only mode

### Capture path
- Hold the row lock across find-and-increment in one transaction (the `.lock` was released before the update on PostgreSQL/MySQL)
- Carry request/session IDs and explicit environment through the reporter → command hop (every request-path occurrence stored nil IDs)
- Reconstruct async exceptions without calling subclass constructors (`ActiveRecord::RecordInvalid` was silently dropped in async mode)
- Snapshot strings, arrays and hashes at raise time so `ensure` blocks don't overwrite what is shown
- Fit string metadata to its columns so an over-long value cannot lose the capture (MySQL strict mode)

### Analytics
- Scope the resolution-rate numerator to the filtered application (rate could read 300%)
- Attribute each occurrence to the release it happened under; `ReleaseTimeline` counts occurrences per release (**new migration** `add_release_to_error_occurrences`, with a portable backfill)
- Baselines: bucket by calendar period through groupdate (the old SQL was SQLite-only and could not run on PostgreSQL/MySQL), zero-filled, occurrence-based, Rails week start, matching-unit anomaly checks, application-scoped current counts; `BaselineCalculationJob` now exists as the docs claimed

### Health snapshot
- Cache job-queue depth counts per process, single-flight refresh, failures cached, switchable off; README claim corrected

### Upgrade notes
`docs/MIGRATION_STRATEGY.md` → "Upgrading to v0.11.6": migration steps, the long-message fingerprint regrouping (errors with messages > 500 chars open a new group on upgrade), the 255-char metadata clamp, and the scope of baseline checks.

## Verification

| Check | Result |
|---|---|
| Full suite, SQLite, Rails 8.0.4 | 4459 examples, 0 failures, 1 pending |
| Full suite, SQLite, Rails 8.1.3.1 | 4459 examples, 0 failures, 1 pending |
| Affected examples on PostgreSQL 16 | 516 examples, 0 failures |
| Affected examples on MySQL 26.7 (trilogy) | 125 examples, 1 pre-existing failure (500-char version into varchar(255), since fixed by the clamp) |
| Full non-system suite on MySQL, migration specs excluded | 4292 examples, 1 pre-existing failure (same) |
| Row lock under real concurrency (16 threads × 5), PostgreSQL | old shape lost 66/80; fixed 81/81 |
| Row lock under real concurrency, MySQL | old shape lost 71/80; fixed 81/81 |
| Strict-mode MySQL metadata smoke test (both persistence paths) | 4 examples, 0 failures |
| Chaos tests (`bin/pre-release-test all`) | 1448 assertions; one wall-clock timing flake under CPU contention, passes idle |
| Independent reviewer's defect probes (2 rounds) | all defects gone; fingerprint regrouping retained by decision |

## Deliberately out of scope (follow-up PR)
PostgreSQL/MySQL CI rows, building the test DB from the gem's migrations (and changing `rails_helper` accordingly), isolating DDL migration specs from transactional cleanup, and documenting/verifying MySQL time zone tables. Those are test-infrastructure changes; the review is satisfied without them.

## Notes for the release
- The demo app needs the new migration plus both schema dumps before upgrading.
- Merge, then let release-please open the 0.11.6 release PR; do not merge that one unattended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Je5ozi8CCwqFow2HfGxfFK
