### PR TITLE
test(llm): reset llm_pricing_overrides after each cost-estimator example

### DIFF
--- a/spec/services/llm_cost_estimator_spec.rb
+++ b/spec/services/llm_cost_estimator_spec.rb
@@ -4,7 +4,12 @@ require "rails_helper"
 
 RSpec.describe RailsErrorDashboard::Services::LlmCostEstimator do
   describe ".estimate" do
+    # Reset in `after` as well as `before`: the override examples below leave
+    # claude-sonnet-4-6 priced at 99/99, and llm_middleware_spec asserts the
+    # built-in rate for that model. With a `before` alone the leak depends on
+    # example order (seed 65083 hit it on Ruby 3.3 / Rails 8.0 in CI).
     before { RailsErrorDashboard.configuration.llm_pricing_overrides = {} }
+    after { RailsErrorDashboard.configuration.llm_pricing_overrides = {} }
 
     context "known models" do
       it "estimates cost for claude-sonnet-4-6" do


### PR DESCRIPTION
## Summary

Order-dependent spec failure that blocked the 0.11.6 release PR (#205) on its first Tests run (Ruby 3.3 / Rails 8.0, seed 65083). Test-only change; no gem code touched.

`spec/services/llm_cost_estimator_spec.rb` cleared `configuration.llm_pricing_overrides` in a `before` hook only, so whichever override its last example set outlived the group. When "uses override when set" (claude-sonnet-4-6 at 99/99) ran last and before `llm_middleware_spec`, the middleware's Anthropic cost assertion saw `0.19008` (1500×99 + 420×99 over 1M) instead of the built-in-rate `0.0108`.

Fix: an `after` hook that resets the overrides too.

## Verification

```
rspec --seed 5 -e "uses override when set" -e "maps Anthropic usage fields"
```

fails on main (`expected "0.0108", got "0.19008"`) and passes on this branch. Full suite, RuboCop, bundle-audit and the chaos tests all passed in the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Je5ozi8CCwqFow2HfGxfFK
