### PR TITLE
fix(migrations): give PostgreSQL search the index it actually uses

### DIFF
--- a/_guides/database-optimization.md
+++ b/_guides/database-optimization.md
@@ -118,30 +118,36 @@ add_index :error_logs, :occurred_at, where: "resolved = false"
 
 #### 2. **GIN Full-Text Search Index**
 ```sql
-CREATE INDEX index_error_logs_on_message_gin
+CREATE INDEX index_error_logs_on_searchable_text
 ON rails_error_dashboard_error_logs
-USING gin(to_tsvector('english', message))
+USING gin(to_tsvector('english',
+  COALESCE(message, '') || ' ' || COALESCE(backtrace, '') || ' ' || COALESCE(error_type, '')
+))
 ```
 
 **What is GIN?** Generalized Inverted Index for full-text search
-- **100-1000x faster** than LIKE queries on large datasets
 - **Supports ranking** by relevance
 - **Case-insensitive** by default
 - **Handles word stemming** (searching "fail" finds "failed", "failing")
 
-**Use case:** Search functionality in error dashboard
+**Use case:** the dashboard's search box. On PostgreSQL it matches against
+message, backtrace and error type together, and PostgreSQL uses an expression
+index only when the query's expression is identical to the index's — which is
+why the index covers exactly that concatenation and nothing else.
 ```ruby
-# Automatically uses GIN index on PostgreSQL:
+# Uses index_error_logs_on_searchable_text on PostgreSQL:
 ErrorsList.call(search: "payment failed")
 ```
 
-**Performance comparison:**
-| Records | LIKE Query | GIN Index | Speedup |
-|---------|-----------|-----------|---------|
-| 10K     | 50ms      | 2ms       | 25x     |
-| 100K    | 500ms     | 5ms       | 100x    |
-| 1M      | 5000ms    | 10ms      | 500x    |
-| 10M     | 50000ms   | 20ms      | 2500x   |
+**Measured** (PostgreSQL 16, 200,000 error logs, a term present in one row,
+searching all errors): 992 ms without the index, 0.012 ms with it. A common
+term looks fast either way because the query stops at the first page of hits.
+
+**Upgrading:** installs created from the squashed migration before 0.11.8 had
+no usable search index (0.11.7 added one on `message` alone, which the search
+never matches). Run `rails rails_error_dashboard:install:migrations db:migrate`
+to get `index_error_logs_on_searchable_text`; the migration also drops the
+unused `message`-only index.
 
 ---
 

--- a/db/migrate/20260909000001_replace_message_gin_with_searchable_text_index.rb
+++ b/db/migrate/20260909000001_replace_message_gin_with_searchable_text_index.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# The dashboard's PostgreSQL full-text search (Queries::ErrorsList#filter_by_search)
+# matches against message, backtrace and error_type together:
+#
+#   to_tsvector('english', COALESCE(message, '') || ' ' || COALESCE(backtrace, '') || ' ' || COALESCE(error_type, ''))
+#
+# PostgreSQL uses an expression index only when the query's expression is
+# identical to the index's, so of the two GIN indexes defined over time only
+# one can serve that search:
+#
+#   index_error_logs_on_message_gin       to_tsvector('english', message)              never used by any query
+#   index_error_logs_on_searchable_text   the expression above                          the one the search needs
+#
+# Which of them a host has depends on how it was installed. Hosts that ran the
+# incremental chain got both; hosts installed from the squashed first migration
+# got neither (the later index migrations skip themselves once the squash's
+# composite indexes exist), and 0.11.7 then added only the message-only one.
+#
+# This converges every install on index_error_logs_on_searchable_text alone.
+# No-op on other adapters.
+class ReplaceMessageGinWithSearchableTextIndex < ActiveRecord::Migration[7.0]
+  TABLE = :rails_error_dashboard_error_logs
+
+  def up
+    return unless postgresql?
+    return unless table_exists?(TABLE)
+
+    execute <<~SQL
+      CREATE INDEX IF NOT EXISTS index_error_logs_on_searchable_text
+      ON rails_error_dashboard_error_logs
+      USING gin(to_tsvector('english',
+        COALESCE(message, '') || ' ' || COALESCE(backtrace, '') || ' ' || COALESCE(error_type, '')
+      ))
+    SQL
+
+    execute "DROP INDEX IF EXISTS index_error_logs_on_message_gin"
+  end
+
+  def down
+    return unless postgresql?
+
+    # There is no single state to return to: before this migration a host had
+    # either both indexes or only the message-only one, depending on its
+    # install path. Dropping searchable_text here would take away, on
+    # incremental-chain hosts, an index they had before, and nothing needs
+    # message_gin back. Earlier gem versions run unchanged against the
+    # converged schema.
+    raise ActiveRecord::IrreversibleMigration,
+          "this migration converges two index layouts (see its header); the previous layout is not recoverable"
+  end
+
+  private
+
+  def postgresql?
+    connection.adapter_name.downcase == "postgresql"
+  end
+end

--- a/docs/guides/DATABASE_OPTIMIZATION.md
+++ b/docs/guides/DATABASE_OPTIMIZATION.md
@@ -118,30 +118,36 @@ add_index :error_logs, :occurred_at, where: "resolved = false"
 
 #### 2. **GIN Full-Text Search Index**
 ```sql
-CREATE INDEX index_error_logs_on_message_gin
+CREATE INDEX index_error_logs_on_searchable_text
 ON rails_error_dashboard_error_logs
-USING gin(to_tsvector('english', message))
+USING gin(to_tsvector('english',
+  COALESCE(message, '') || ' ' || COALESCE(backtrace, '') || ' ' || COALESCE(error_type, '')
+))
 ```
 
 **What is GIN?** Generalized Inverted Index for full-text search
-- **100-1000x faster** than LIKE queries on large datasets
 - **Supports ranking** by relevance
 - **Case-insensitive** by default
 - **Handles word stemming** (searching "fail" finds "failed", "failing")
 
-**Use case:** Search functionality in error dashboard
+**Use case:** the dashboard's search box. On PostgreSQL it matches against
+message, backtrace and error type together, and PostgreSQL uses an expression
+index only when the query's expression is identical to the index's — which is
+why the index covers exactly that concatenation and nothing else.
 ```ruby
-# Automatically uses GIN index on PostgreSQL:
+# Uses index_error_logs_on_searchable_text on PostgreSQL:
 ErrorsList.call(search: "payment failed")
 ```
 
-**Performance comparison:**
-| Records | LIKE Query | GIN Index | Speedup |
-|---------|-----------|-----------|---------|
-| 10K     | 50ms      | 2ms       | 25x     |
-| 100K    | 500ms     | 5ms       | 100x    |
-| 1M      | 5000ms    | 10ms      | 500x    |
-| 10M     | 50000ms   | 20ms      | 2500x   |
+**Measured** (PostgreSQL 16, 200,000 error logs, a term present in one row,
+searching all errors): 992 ms without the index, 0.012 ms with it. A common
+term looks fast either way because the query stops at the first page of hits.
+
+**Upgrading:** installs created from the squashed migration before 0.11.8 had
+no usable search index (0.11.7 added one on `message` alone, which the search
+never matches). Run `rails rails_error_dashboard:install:migrations db:migrate`
+to get `index_error_logs_on_searchable_text`; the migration also drops the
+unused `message`-only index.
 
 ---
 

--- a/spec/db/migrations/optimized_indexes_spec.rb
+++ b/spec/db/migrations/optimized_indexes_spec.rb
@@ -106,42 +106,4 @@ RSpec.describe "Optimized Indexes Migration", type: :migration do
       expect(result).to be_present
     end
   end
-
-  describe "PostgreSQL-specific indexes", if: ActiveRecord::Base.connection.adapter_name.downcase == 'postgresql' do
-    it "creates partial index for unresolved errors" do
-      indexes = connection.indexes(table_name)
-      index = indexes.find { |i| i.name == 'index_error_logs_on_occurred_at_unresolved' }
-
-      expect(index).to be_present
-      expect(index.where).to eq("(resolved = false)")
-    end
-
-    it "creates GIN index for full-text search on message" do
-      # Check if GIN index exists
-      result = connection.execute(<<-SQL)
-        SELECT indexname
-        FROM pg_indexes
-        WHERE tablename = 'rails_error_dashboard_error_logs'
-        AND indexname = 'index_error_logs_on_message_gin'
-      SQL
-
-      expect(result.to_a).not_to be_empty
-    end
-
-    it "improves full-text search performance" do
-      # Create test errors with searchable text (the factory supplies the
-      # application the model requires; this example only ever ran on
-      # PostgreSQL and predates that validation)
-      create(:error_log, error_type: "StandardError",
-                         message: "Payment processing failed for transaction", occurred_at: Time.current)
-
-      # This query should use the GIN index
-      result = connection.execute(<<-SQL)
-        SELECT * FROM rails_error_dashboard_error_logs
-        WHERE to_tsvector('english', message) @@ to_tsquery('english', 'payment')
-      SQL
-
-      expect(result.to_a.count).to eq(1)
-    end
-  end
 end

--- a/spec/db/postgresql_indexes_spec.rb
+++ b/spec/db/postgresql_indexes_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# The PostgreSQL-only indexes the query layer relies on, checked against the
+# schema this run was built with. On the CI PostgreSQL row that schema comes
+# from db/migrate (RED_TEST_SCHEMA=migrations), so these examples see exactly
+# what a fresh install gets — the gap this guards against went unnoticed for
+# nine months because the squashed first migration omitted these indexes and
+# nothing ran on PostgreSQL to notice.
+RSpec.describe "PostgreSQL-only indexes", if: ActiveRecord::Base.connection.adapter_name.downcase == "postgresql" do
+  let(:connection) { ActiveRecord::Base.connection }
+  let(:table_name) { :rails_error_dashboard_error_logs }
+
+  def index_names
+    connection.select_values(
+      "SELECT indexname FROM pg_indexes WHERE tablename = #{connection.quote(table_name.to_s)}"
+    )
+  end
+
+  it "has the partial index on unresolved rows" do
+    index = connection.indexes(table_name).find { |i| i.name == "index_error_logs_on_occurred_at_unresolved" }
+
+    expect(index).to be_present
+    expect(index.columns).to eq([ "occurred_at" ])
+    expect(index.where).to eq("(resolved = false)")
+  end
+
+  describe "full-text search" do
+    # The real search query, stripped to its predicate: no ordering, no
+    # resolved filter (unresolved: false), no pagination. With sequential
+    # scans disabled the planner can satisfy the predicate only through an
+    # index whose expression matches the query's, so the plan names the
+    # index the search actually uses — or none.
+    def search_plan
+      sql = RailsErrorDashboard::Queries::ErrorsList
+              .call(search: "payment", unresolved: false)
+              .unscope(:order)
+              .select(:id)
+              .to_sql
+
+      connection.transaction(requires_new: true) do
+        connection.execute("SET LOCAL enable_seqscan = off")
+        connection.select_values("EXPLAIN #{sql}").join("\n")
+      end
+    end
+
+    it "is served by index_error_logs_on_searchable_text" do
+      expect(index_names).to include("index_error_logs_on_searchable_text")
+      expect(search_plan).to include("index_error_logs_on_searchable_text")
+    end
+
+    it "does not carry the message-only GIN index" do
+      # Its expression (message alone) matches no query the gem runs, so it
+      # was only ever write overhead. Replaced by
+      # 20260909000001_replace_message_gin_with_searchable_text_index.
+      expect(index_names).not_to include("index_error_logs_on_message_gin")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Verifying 0.11.7's PostgreSQL index fix against a real PostgreSQL 16 showed it added an index nothing reads, while the index the search needs is still missing on fresh installs. This converges every install path on the correct one and adds the guard that would have caught it.

### What was wrong

The search (`Queries::ErrorsList#filter_by_search`) runs `to_tsvector('english', message || ' ' || backtrace || ' ' || error_type)`. PostgreSQL uses an expression index only when the expression is identical, so:

| Index | Expression | Used by the search |
|---|---|---|
| `index_error_logs_on_message_gin` | `message` alone | never (0 scans across every query run; 12 MB per 200k rows, maintained on each insert) |
| `index_error_logs_on_searchable_text` | the concatenation | yes |

Which one a host has depends on install path: incremental chain → both; fresh install from the squash → neither (the later index migrations return early once the squash's composites exist); 0.11.7 → message_gin only.

Measured, 200,000 rows, rare term, all errors: **992 ms without searchable_text, 0.012 ms with it.** Common terms look fast without it only because the query stops at the first page.

### The fix

- **New migration `20260909000001`** creates `index_error_logs_on_searchable_text` if missing and drops `index_error_logs_on_message_gin`. No-op off PostgreSQL. Irreversible by declaration: there is no single prior layout to restore, and earlier gem versions run unchanged against the converged one.
- **Guard spec `spec/db/postgresql_indexes_spec.rb`**: on the CI PostgreSQL row (schema built from `db/migrate`, i.e. a fresh install) it runs the real search predicate under `EXPLAIN` with sequential scans disabled and requires the plan to name `searchable_text`; it also rejects the message-only index. Verified to fail on the 0.11.7 layout and pass on fresh PostgreSQL, a simulated incremental-chain host, and MySQL (skipped). The message_gin assertions leave `optimized_indexes_spec`.
- **Docs**: `DATABASE_OPTIMIZATION.md` and its `_guides` mirror describe the real index, the measured numbers, and the upgrade step.

### Deliberately not done

- The snooze partial index the squash also omitted is not added: `ErrorLog.snoozed` is unused, and `ErrorLog.active` (`IS NULL OR ...`) cannot use a partial index on `IS NOT NULL` rows.
- No shipped migration is edited. The 0.11.7 migration still creates message_gin on an upgrade from ≤ 0.11.6; the new migration drops it in the same `db:migrate`.
- The partial unresolved index 0.11.7 added is kept: redundant with the composite `(resolved, occurred_at)` for the default list (0.025 ms either way) but smaller, and harmless.

### Verification

| Run | Result |
|---|---|
| Fresh PostgreSQL 16, migrations, index + migration specs | 17 examples, 0 failures; only `searchable_text` GIN present |
| Simulated incremental-chain host (both GIN indexes) | converges to `searchable_text` only; `down` refused, schema intact |
| Guard spec on the 0.11.7 layout | 2 of 3 fail (as intended) |
| Fresh MySQL 26.7, migrations, same specs | 14 examples, 0 failures; migration recorded, no-op |
| `bin/check-schema-parity` (SQLite) | agree, 10 tables |
| Pre-commit: full suite, RuboCop, bundle-audit, chaos tests | all green |

PostgreSQL hosts pick this up with `rails rails_error_dashboard:install:migrations db:migrate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Je5ozi8CCwqFow2HfGxfFK
